### PR TITLE
fix: index empty (zero-byte) notes instead of dropping them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1879,16 +1879,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -2093,9 +2093,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -2105,9 +2105,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.23",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-            "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+            "version": "4.12.28",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
+            "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
@@ -3851,9 +3851,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-            "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"

--- a/src/index-sync.test.ts
+++ b/src/index-sync.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { deriveContent, applyIndexChange, type IndexTarget } from "./index-sync.js";
+
+/**
+ * Regression tests for zero-byte notes being dropped from the search index
+ * (issues #5 cold-start and #6 list_notes). A deleted note must be removed; an
+ * empty-but-present note must be indexed. The old `if (content)` truthiness
+ * check conflated the two and dropped empty notes.
+ */
+
+// Minimal stand-in for SearchIndex.
+class FakeIndex implements IndexTarget {
+    private paths = new Set<string>();
+    update(path: string) { this.paths.add(path); }
+    remove(path: string) { this.paths.delete(path); }
+    has(path: string) { return this.paths.has(path); }
+    get size() { return this.paths.size; }
+}
+
+describe("deriveContent — delete vs empty", () => {
+    it("returns null for a deleted note", () => {
+        assert.equal(deriveContent({ deleted: true, data: [""] }), null);
+    });
+    it("returns '' for an existing empty note (data: [])", () => {
+        assert.equal(deriveContent({ data: [] }), "");
+    });
+    it("returns '' for an existing note with no data array", () => {
+        assert.equal(deriveContent({}), "");
+    });
+    it("returns the joined body for a normal note", () => {
+        assert.equal(deriveContent({ data: ["# Title\n", "body"] }), "# Title\nbody");
+    });
+});
+
+describe("applyIndexChange — routing", () => {
+    let index: FakeIndex;
+    beforeEach(() => { index = new FakeIndex(); });
+
+    it("indexes an empty note instead of dropping it", () => {
+        applyIndexChange(index, "empty.md", "");
+        assert.ok(index.has("empty.md"), "empty note should be indexed");
+    });
+
+    it("removes a note on delete (null content)", () => {
+        applyIndexChange(index, "gone.md", "seed"); // present first
+        applyIndexChange(index, "gone.md", null);
+        assert.ok(!index.has("gone.md"), "deleted note should be removed");
+    });
+
+    it("indexes a normal note", () => {
+        applyIndexChange(index, "note.md", "text");
+        assert.ok(index.has("note.md"));
+    });
+
+    it("reproduces issue #5: 1 content note + 3 empty notes all index", () => {
+        // End-to-end of the cold-start routing over a mixed batch.
+        const changes: Array<[string, string | null]> = [
+            ["alpha.md", "# Alpha\ncontent"],
+            ["beta.md", ""],
+            ["gamma.md", ""],
+            ["delta.md", ""],
+        ];
+        for (const [path, content] of changes) applyIndexChange(index, path, content);
+        assert.equal(index.size, 4, `expected all 4 notes indexed, got ${index.size}`);
+    });
+});

--- a/src/index-sync.ts
+++ b/src/index-sync.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared search-index sync helpers.
+ *
+ * Kept dependency-free (no livesync-commonlib imports) so the delete-vs-empty
+ * routing is unit-testable in isolation.
+ */
+
+export interface IndexTarget {
+    update(path: string, content: string, mtime?: number): void;
+    remove(path: string): void;
+}
+
+/**
+ * Derive index content from a LiveSync change doc.
+ *
+ * Returns `null` ONLY when the note is deleted. An existing note with no body
+ * yields `""` so a zero-byte note stays distinguishable from a deletion —
+ * without this, a note that serializes with no `data` array would look deleted.
+ */
+export function deriveContent(doc: { deleted?: boolean; data?: unknown }): string | null {
+    if (doc.deleted) return null;
+    return "data" in doc && Array.isArray(doc.data) ? doc.data.join("") : "";
+}
+
+/**
+ * Route a change into the index: `null` content removes (the note was deleted),
+ * any string — including `""` — upserts. Using `content !== null` (rather than a
+ * truthiness check) keeps zero-byte notes indexed instead of dropping them
+ * (issues #5 / #6).
+ */
+export function applyIndexChange(index: IndexTarget, path: string, content: string | null, mtime?: number): void {
+    if (content !== null) {
+        index.update(path, content, mtime);
+    } else {
+        index.remove(path);
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { stat } from "fs/promises";
 import { setGlobalLogFunction, LEVEL_INFO } from "octagonal-wheels/common/logger";
 import { mountPasswordAuth } from "./auth.js";
 import { SearchIndex } from "./search.js";
+import { applyIndexChange } from "./index-sync.js";
 import { registerTools } from "./tools.js";
 
 // Suppress livesync-commonlib logs that expose vault file paths in production.
@@ -111,11 +112,8 @@ async function rebuildIndex() {
 
     if (COUCHDB_URL && vault.catchUp) {
         const changeCallback = (path: string, content: string | null, mtime?: number) => {
-            if (content) {
-                searchIndex.update(path, content, mtime);
-            } else {
-                searchIndex.remove(path);
-            }
+            // content === "" is an empty-but-present note: index it, don't drop it.
+            applyIndexChange(searchIndex, path, content, mtime);
         };
 
         let since = searchIndex.since || "0";
@@ -129,7 +127,7 @@ async function rebuildIndex() {
         try {
             const countingCallback = (path: string, content: string | null, mtime?: number) => {
                 changes++;
-                if (debugLogging) console.log(`[debug] Change: ${path} ${content ? "(update)" : "(delete)"}`);
+                if (debugLogging) console.log(`[debug] Change: ${path} ${content !== null ? "(update)" : "(delete)"}`);
                 changeCallback(path, content, mtime);
             };
             const newSince = await vault.catchUp(since, countingCallback, onBatch);
@@ -161,7 +159,8 @@ async function rebuildIndex() {
             for (let i = 0; i < notesWithMtime.length; i++) {
                 const { path, mtime } = notesWithMtime[i];
                 const content = await vault.readNote(path);
-                if (content) searchIndex.update(path, content, mtime);
+                // Index empty notes too (content === ""); readNote returns null only if absent.
+                if (content !== null) searchIndex.update(path, content, mtime);
                 if (notesWithMtime.length > 100 && (i + 1) % 500 === 0) {
                     console.log(`  indexed ${i + 1}/${notesWithMtime.length}...`);
                 }
@@ -208,13 +207,9 @@ if (VAULT_PATH) {
 } else if (COUCHDB_URL && vault.watchChanges) {
     // Remote mode: watch CouchDB _changes feed for LiveSync updates
     vault.watchChanges((path: string, content: string | null, mtime?: number, seq?: string | number) => {
-        if (content) {
-            if (debugLogging) console.log(`[debug] CouchDB change: ${path} (mtime: ${mtime})`);
-            searchIndex.update(path, content, mtime);
-        } else {
-            if (debugLogging) console.log(`[debug] CouchDB delete: ${path}`);
-            searchIndex.remove(path);
-        }
+        if (debugLogging) console.log(`[debug] CouchDB ${content === null ? "delete" : "change"}: ${path}`);
+        // content === "" is an empty-but-present note: index it, don't drop it.
+        applyIndexChange(searchIndex, path, content, mtime);
         if (seq) searchIndex.since = String(seq);
     });
     console.log("Watching CouchDB for LiveSync changes.");

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -273,7 +273,8 @@ export function registerTools(
                 return `Failed to move: ${from} → ${to}`;
             }
             searchIndex.remove(from);
-            if (content) searchIndex.update(to, content, Date.now());
+            // content === "" is an empty-but-present note: keep it indexed at the new path.
+            if (content !== null) searchIndex.update(to, content, Date.now());
             const deepLink = makeDeepLink(vaultName, to);
             return `Moved: ${from} → ${to}\n[Open in Obsidian](${deepLink})`;
         },

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -11,6 +11,7 @@ import { isPathProbablyObfuscated, decrypt } from "octagonal-wheels/encryption/e
 import { clearHandlers } from "../lib/livesync-commonlib/src/replication/SyncParamsHandler.ts";
 import { parseFrontmatterAndLinks } from "./parse.js";
 import type { VaultBackend, NoteInfo, NoteListing } from "./vault-backend.js";
+import { deriveContent } from "./index-sync.js";
 
 export interface VaultConfig {
     couchdbUrl: string;
@@ -58,12 +59,9 @@ export class Vault implements VaultBackend {
     private static docToChange(doc: any, callback: (path: string, content: string | null, mtime?: number, seq?: string | number) => void, seq?: string | number) {
         const path = doc.path ?? "";
         if (!path.endsWith(".md")) return;
-        if (doc.deleted) {
-            callback(path, null, undefined, seq);
-        } else {
-            const content = "data" in doc && Array.isArray(doc.data) ? doc.data.join("") : null;
-            callback(path, content, doc.mtime, seq);
-        }
+        // null => deleted (remove); "" => existing empty note (index it, don't drop)
+        const content = deriveContent(doc);
+        callback(path, content, content === null ? undefined : doc.mtime, seq);
     }
 
     async catchUp(


### PR DESCRIPTION
Cold-start CouchDB sync and local indexing used `if (content)` to decide between updating and removing a note in the search index. An existing note with an empty body has content "", which is falsy, so it was removed from the index instead of indexed — leaving it out of list_notes and search. This is why a fresh vault with mostly title-only notes showed "1 of 4 indexed" (#5), and why zero-byte notes never appeared in list_notes (#6).

Distinguish deleted from empty-but-present:
- Vault.docToChange emits "" (not null) for a non-deleted note, so null uniquely means "deleted".
- The three indexing call sites in main.ts (cold-start catchUp, live-watch, local build) use `content !== null` so empty notes are indexed and only actual deletions remove.

Extracted deriveContent/applyIndexChange into index-sync.ts with unit tests covering delete vs empty routing. Verified against a real CouchDB cold start: old behavior indexed 1 of 4 notes, fixed behavior indexes 4 of 4.

Closes #5, see #7.