### PR TITLE
fix(auth): honor requested token_endpoint_auth_method on DCR

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -124,6 +124,41 @@ describe("Dynamic Client Registration", () => {
         assert.ok(body.client_id);
         assert.ok(body.client_secret);
         assert.deepEqual(body.redirect_uris, ["https://x.com/cb"]);
+        assert.equal(body.token_endpoint_auth_method, "client_secret_post");
+    });
+
+    it("honors token_endpoint_auth_method: none — no client_secret issued", async () => {
+        const { app } = setup();
+        const resp = await app.request("/oauth/register", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                client_name: "test",
+                redirect_uris: ["https://x.com/cb"],
+                token_endpoint_auth_method: "none",
+            }),
+        });
+        assert.equal(resp.status, 201);
+        const body = (await resp.json()) as any;
+        assert.equal(body.token_endpoint_auth_method, "none");
+        assert.equal(body.client_secret, undefined);
+    });
+
+    it("falls back to client_secret_post for an unrecognized auth method", async () => {
+        const { app } = setup();
+        const resp = await app.request("/oauth/register", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                client_name: "test",
+                redirect_uris: ["https://x.com/cb"],
+                token_endpoint_auth_method: "client_secret_basic",
+            }),
+        });
+        assert.equal(resp.status, 201);
+        const body = (await resp.json()) as any;
+        assert.equal(body.token_endpoint_auth_method, "client_secret_post");
+        assert.ok(body.client_secret);
     });
 });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -193,7 +193,7 @@ export function mountPasswordAuth(app: Hono, baseUrl: string, password: string, 
 
         console.log(
             `Auth: registered client_id=${clientId} redirect_uris=${JSON.stringify(redirectUris)} ` +
-            `requested_auth_method=${body.token_endpoint_auth_method ?? "(unspecified)"} (responding with ${tokenEndpointAuthMethod})`
+            `requested_auth_method=${JSON.stringify(body.token_endpoint_auth_method ?? "(unspecified)")} (responding with ${tokenEndpointAuthMethod})`
         );
 
         return c.json({

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -38,7 +38,8 @@ interface TokenRecord {
 
 interface RegisteredClient {
     clientId: string;
-    clientSecret: string;
+    clientSecret?: string;
+    tokenEndpointAuthMethod: "client_secret_post" | "none";
     redirectUris: string[];
     clientName?: string;
     createdAt?: number;
@@ -170,12 +171,19 @@ export function mountPasswordAuth(app: Hono, baseUrl: string, password: string, 
         }
 
         const clientId = randomUUID();
-        const clientSecret = randomBytes(32).toString("hex");
+        // Honor the client's requested auth method (RFC 7591 §2). Only
+        // "client_secret_post" and "none" are advertised as supported, so
+        // anything else falls back to the confidential-client default rather
+        // than silently registering a method we don't understand.
+        const tokenEndpointAuthMethod: "client_secret_post" | "none" =
+            body.token_endpoint_auth_method === "none" ? "none" : "client_secret_post";
+        const clientSecret = tokenEndpointAuthMethod === "none" ? undefined : randomBytes(32).toString("hex");
         const clientName = typeof body.client_name === "string" ? body.client_name.slice(0, 256) : undefined;
 
         const client: RegisteredClient = {
             clientId,
             clientSecret,
+            tokenEndpointAuthMethod,
             redirectUris,
             clientName,
             createdAt: Date.now(),
@@ -183,12 +191,17 @@ export function mountPasswordAuth(app: Hono, baseUrl: string, password: string, 
         clients.set(clientId, client);
         await persist();
 
+        console.log(
+            `Auth: registered client_id=${clientId} redirect_uris=${JSON.stringify(redirectUris)} ` +
+            `requested_auth_method=${body.token_endpoint_auth_method ?? "(unspecified)"} (responding with ${tokenEndpointAuthMethod})`
+        );
+
         return c.json({
             client_id: clientId,
-            client_secret: clientSecret,
+            ...(clientSecret ? { client_secret: clientSecret } : {}),
             redirect_uris: client.redirectUris,
             client_name: client.clientName,
-            token_endpoint_auth_method: "client_secret_post",
+            token_endpoint_auth_method: tokenEndpointAuthMethod,
         }, 201);
     });
 
@@ -204,14 +217,20 @@ export function mountPasswordAuth(app: Hono, baseUrl: string, password: string, 
         // Validate redirect URI against registered client
         const client = clients.get(clientId);
         if (!client) {
+            console.warn(`Auth: /oauth/authorize unknown client_id=${JSON.stringify(clientId)}`);
             return c.text("Unknown client", 400);
         }
         if (!client.redirectUris.includes(redirectUri)) {
+            console.warn(
+                `Auth: /oauth/authorize redirect_uri mismatch. received=${JSON.stringify(redirectUri)} ` +
+                `registered=${JSON.stringify(client.redirectUris)}`
+            );
             return c.text("Invalid redirect URI", 400);
         }
 
         // Require S256 PKCE
         if (codeChallengeMethod !== "S256" || !codeChallenge) {
+            console.warn(`Auth: /oauth/authorize missing/unsupported PKCE. method=${JSON.stringify(codeChallengeMethod)} challenge_present=${!!codeChallenge}`);
             return c.text("PKCE with S256 is required", 400);
         }
 
@@ -230,6 +249,8 @@ export function mountPasswordAuth(app: Hono, baseUrl: string, password: string, 
             code,
             createdAt: Date.now(),
         });
+
+        console.log(`Auth: /oauth/authorize accepted client_id=${clientId} redirect_uri=${JSON.stringify(redirectUri)}`);
 
         const csrf = randomBytes(32).toString("hex");
         csrfTokens.set(code, csrf);
@@ -307,6 +328,7 @@ export function mountPasswordAuth(app: Hono, baseUrl: string, password: string, 
     app.post("/oauth/token", async (c) => {
         const body = await c.req.parseBody();
         const grantType = body["grant_type"] as string;
+        console.log(`Auth: /oauth/token request grant_type=${JSON.stringify(grantType)}`);
 
         if (grantType === "authorization_code") {
             const code = body["code"] as string;
@@ -316,17 +338,27 @@ export function mountPasswordAuth(app: Hono, baseUrl: string, password: string, 
 
             const pending = pendingAuths.get(code);
             if (!pending || Date.now() - pending.createdAt > PENDING_TTL_MS) {
+                console.warn(
+                    `Auth: /oauth/token invalid_grant. code_known=${!!pending} ` +
+                    `expired=${pending ? Date.now() - pending.createdAt > PENDING_TTL_MS : "n/a"}`
+                );
                 if (pending) pendingAuths.delete(code);
                 return c.json({ error: "invalid_grant" }, 400);
             }
 
             // Verify client_id matches the original request
             if (clientId !== pending.clientId) {
+                console.warn(
+                    `Auth: /oauth/token client_id mismatch. received=${JSON.stringify(clientId)} expected=${JSON.stringify(pending.clientId)}`
+                );
                 return c.json({ error: "invalid_grant", error_description: "client_id mismatch" }, 400);
             }
 
             // Verify redirect_uri matches the original request
             if (redirectUri !== pending.redirectUri) {
+                console.warn(
+                    `Auth: /oauth/token redirect_uri mismatch. received=${JSON.stringify(redirectUri)} expected=${JSON.stringify(pending.redirectUri)}`
+                );
                 return c.json({ error: "invalid_grant", error_description: "redirect_uri mismatch" }, 400);
             }
 
@@ -336,11 +368,13 @@ export function mountPasswordAuth(app: Hono, baseUrl: string, password: string, 
                     .update(codeVerifier)
                     .digest("base64url");
                 if (expected !== pending.codeChallenge) {
+                    console.warn("Auth: /oauth/token PKCE verification failed");
                     return c.json({ error: "invalid_grant", error_description: "PKCE verification failed" }, 400);
                 }
             }
 
             pendingAuths.delete(code);
+            console.log(`Auth: /oauth/token issuing access token client_id=${pending.clientId}`);
 
             const accessToken = randomBytes(32).toString("hex");
             const refreshToken = randomBytes(32).toString("hex");
@@ -367,6 +401,7 @@ export function mountPasswordAuth(app: Hono, baseUrl: string, password: string, 
             const refreshToken = body["refresh_token"] as string;
             const old = refreshTokens.get(refreshToken);
             if (!old) {
+                console.warn("Auth: /oauth/token refresh_token unknown");
                 return c.json({ error: "invalid_grant" }, 400);
             }
 
@@ -402,6 +437,7 @@ export function mountPasswordAuth(app: Hono, baseUrl: string, password: string, 
             });
         }
 
+        console.warn(`Auth: /oauth/token unsupported_grant_type=${JSON.stringify(grantType)}`);
         return c.json({ error: "unsupported_grant_type" }, 400);
     });
 


### PR DESCRIPTION
## Summary

While debugging a Claude.ai custom connector that couldn't complete the OAuth flow, I found two real issues in `src/auth.ts`:

- **`/oauth/register` ignores the client's requested `token_endpoint_auth_method`.** It always returns `token_endpoint_auth_method: "client_secret_post"` and issues a `client_secret`, even when a client explicitly registers as a public client with `"none"` (which is advertised as supported in `token_endpoint_auth_methods_supported`). This can confuse OAuth clients that expect the server to honor a public-client registration.
- **The `/oauth/token` authorization_code grant never logs its rejection reasons.** Every `invalid_grant` branch (expired/unknown code, `client_id` mismatch, `redirect_uri` mismatch, PKCE failure) returns silently with no `console.warn`/`console.log`. In practice this made a rejected token exchange indistinguishable from a request that never reached the server at all, which made diagnosing a real connector failure much harder than it needed to be.

(For context: the connector issue I was chasing turned out to be an unrelated Cloudflare geo-blocking rule on my own deployment, not caused by either of these. But both issues are real and worth fixing on their own.)

## Changes

- `/oauth/register` now honors `token_endpoint_auth_method: "none"` — no `client_secret` is issued or returned, and the response is honest about the method. Anything other than `"none"` still falls back to `client_secret_post`, matching what's advertised in discovery metadata.
- Added diagnostic logging across `/oauth/register`, `/oauth/authorize`, and `/oauth/token` — particularly every rejection branch of the authorization_code and refresh_token grants — so a failed exchange is visible in server logs with enough detail (received vs. expected `client_id`/`redirect_uri`) to self-diagnose.
- Added test coverage for the `"none"` auth method and for falling back on an unrecognized method.

## Test plan

- [x] `node --import tsx --test src/auth.test.ts` — 26/26 passing
- [x] `npx tsup` build succeeds
- [x] Manually verified against a running deployment: registered a client with `token_endpoint_auth_method: "none"`, confirmed no `client_secret` is returned and the log line reflects it
