### PR TITLE
ci: publish multi-arch (amd64+arm64) Docker image

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -180,11 +180,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
The published ghcr.io image only shipped an amd64 layer, causing "exec format error" on arm64 hosts like Raspberry Pi 4. The app has no native/compiled dependencies (pouchdb-*, fflate, xxhash-wasm are pure JS/WASM), so this is purely a CI publishing gap.

Add docker/setup-qemu-action and docker/setup-buildx-action before the build step, and set platforms: linux/amd64,linux/arm64 on docker/build-push-action so buildx cross-builds and pushes a multi-platform manifest.