### PR TITLE
feat: restore persistent full-text search with encrypted SQLite

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm audit --audit-level=high
 
   build:
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run build
       - run: npm pack --dry-run
       - run: npm pack
@@ -54,14 +54,19 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # 22.13 segfaults in better-sqlite3-multiple-ciphers; keep the exact
+        # supported floor and the other supported LTS line under test.
+        node-version: ["22.14.0", "24"]
     steps:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: actions/setup-node@v5
         with:
-          node-version: "22"
-      - run: npm ci
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci --ignore-scripts
       - run: npm test
 
   # E2E: start server in local mode, test all tools via MCP protocol
@@ -75,7 +80,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run build
       - run: npm run test:e2e
 
@@ -104,7 +109,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run test:couchdb
 
   release:
@@ -148,17 +153,14 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      # Node 20 (LTS) — Node 22.22.2's bundled npm is broken on GHA runners
-      # (nodejs/node#62425), causing both self-upgrade crashes and OIDC publish
-      # failures. Node 20's bundled npm self-upgrades cleanly.
+      # The encrypted SQLite dependency supports the Node 22 and 24 lines.
+      # Use Node 24 here to avoid the npm bug in Node 22.22.2 (nodejs/node#62425).
       - uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      # Pin to npm 11.x: npm@latest (12.x) dropped Node 20 support (requires
-      # node >=22.22.2). npm 11 supports Node 20.17+ and OIDC trusted publishing.
-      - run: npm install -g npm@11
-      - run: npm ci
+      - run: npm install -g npm@latest
+      - run: npm ci --ignore-scripts
       - run: npm run build
       - run: npm publish --provenance --access public
 
@@ -173,7 +175,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run build
       - uses: docker/login-action@v3
         with:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,48 +19,81 @@ The MCP server sits between CouchDB (or the local filesystem) and AI agents. It 
 ### Filesystem mode (`VAULT_PATH`)
 - Reads `.md` files directly from a vault directory
 - File watcher (debounced, 100ms per path) detects external edits
-- Startup: loads persisted index, diffs mtimes against filesystem, reads only changed files
+- Startup: opens the SQLite index, diffs mtimes against filesystem, reads only changed files
 
 ### CouchDB mode (`COUCHDB_URL`)
 - Uses `DirectFileManipulator` from [livesync-commonlib](https://github.com/vrtmrz/livesync-commonlib) to read/write CouchDB documents
 - Handles E2E encryption (decrypt on read, encrypt on write) when `COUCHDB_PASSPHRASE` is set
 - Handles chunk reassembly (large notes are split into chunks by LiveSync)
-- Startup: loads persisted index, catches up via CouchDB `_changes` feed from stored `since` sequence
+- Startup: opens the SQLite index and catches up via CouchDB `_changes` from its stored `since` sequence
 - Live watcher: `_changes` feed with `live: true` for real-time updates
 
-## Search Index (`src/search.ts`)
+## Search indexes (`src/search.ts`, `src/full-text-search.ts`)
 
-A single `SearchIndex` class manages all indexed data in memory:
+A `SearchIndex` facade uses in-memory maps only when `FULL_TEXT_SEARCH=false`.
+The default path keeps durable search and metadata in one SQLite database:
 
 ```
-(no full-text search — metadata only)
-knownPaths: Set<string>   ─── all indexed note paths
-mtimes: Map<path, number> ─── modification timestamps
-tags: Map<path, string[]> ─── extracted from frontmatter + inline #tags
-links: Map<path, string[]>── outgoing [[wikilinks]] and [markdown](links.md)
-backlinks: Map<target, Set<source>> ─── reverse link index (case-insensitive keys)
-since: string             ─── CouchDB _changes sequence (CouchDB mode only)
+notes         ─── path, mtime, content hash, title, normalized lookup fields
+note_aliases  ─── exact and prefix alias lookup
+note_tags     ─── exact tag filtering and counts
+note_links    ─── outgoing links plus indexed backlink targets
+chunks        ─── heading-level passages with hierarchy breadcrumbs
+index_meta    ─── CouchDB `since` checkpoint
+notes_fts     ─── compact metadata candidate lane
+chunks_fts    ─── one Porter-stemmed passage index
 ```
+
+Markdown is split at headings; oversized sections are divided at paragraph
+boundaries with no overlap. Search combines exact SQL title/alias/path matches,
+metadata FTS, and stemmed passage BM25 using reciprocal-rank fusion. Passage
+matches are grouped to one best chunk per note before the final limit, avoiding
+long-note result flooding. Bodies are not retained in the JavaScript heap.
+
+`FULL_TEXT_SEARCH=auto` (the default) and `true` enable FTS for every vault.
+When a CouchDB passphrase is configured, scrypt first makes passphrase guessing
+expensive and HKDF then derives a backend-specific index key. The database uses
+SQLCipher-compatible AES-256 encryption with authenticated pages. Local and
+unencrypted remote vaults use ordinary SQLite because their source notes are
+already plaintext at rest. `FULL_TEXT_SEARCH=false` disables the tool and all
+index persistence, leaving an existing SQLite file untouched.
 
 ### Persistence
 
-Everything is serialized to a single JSON file at `DATA_DIR/<vault-hash>/search-index.json`:
-- No full-text index (removed FlexSearch for memory efficiency)
-- Metadata (mtimes, tags, links, since)
-- Encrypted with AES-256-GCM when `COUCHDB_PASSPHRASE` is set
-- Saved every 5 minutes + on graceful shutdown
-- Concurrent saves guarded by a lock flag
+Search v2 is stored at
+`DATA_DIR/backends/<backend-hash>/full-text-index-v2.sqlite` with mode `0600`.
+The hash comes from the canonical filesystem root or the credential-free
+CouchDB URL plus database name—not `VAULT_NAME`. That opaque identity is also
+stored in SQLite and included in encrypted-index key derivation, preventing
+results or a CouchDB checkpoint from being reused for another backend.
+SQLite incrementally commits metadata and content; there is no JSON
+snapshot or five-minute search-index save timer. CouchDB changes and their
+sequence checkpoint commit in the same bounded transaction, with an event-loop
+yield between batches. An incompatible schema is renamed to a timestamped
+`.bak` file before a clean rebuild.
+
+SQLite uses `DELETE` journaling and in-memory temporary tables. Encrypted index
+rollback journals contain encrypted pages, and encrypted schema/identity backups
+remain encrypted. The database, live journal, migration outputs, and backups are
+covered by plaintext-marker and `0600` permission tests. Plaintext-to-encrypted
+re-keying cannot erase copies retained by external snapshots or backups.
+
+The old `full-text-index.sqlite` file and the prototype
+`DATA_DIR/<vault-name-hash>/full-text-index-v2.sqlite` are deliberately
+untouched. Because the prototype cannot prove its backend ownership, this
+release rebuilds once instead of importing it. OAuth tokens remain at their
+established path, so the search migration does not force reauthentication.
 
 ### Startup flow
 
 **CouchDB mode:**
 ```
-Load persisted index from disk
+Open v2 SQLite index
   ↓ (has since?)
 catchUp(since) via _changes feed
   → process updates (searchIndex.update)
   → process deletes (searchIndex.remove)
-  → store new since
+  → atomically commit updates and new since every batch
   ↓
 Start live _changes watcher (since: current)
   → updates since on each change
@@ -68,7 +101,7 @@ Start live _changes watcher (since: current)
 
 **Filesystem mode:**
 ```
-Load persisted index from disk
+Open v2 SQLite index
   ↓
 Diff mtimes against filesystem
   → remove stale entries (deleted files)
@@ -83,11 +116,19 @@ CouchDB: catchUp(since: "0") → replays all changes
 Filesystem: full scan of all .md files
 ```
 
+During a build or catch-up, every index-backed tool response (`search_notes`,
+`list_notes`, `list_folders`, `list_tags`, and backlinks from
+`get_note_metadata`) explicitly identifies incomplete or stale data.
+
 ### Fault tolerance
-- Wrong passphrase / corrupted index: `loadFromDisk` catches errors, falls back to full rebuild
+- Wrong passphrase: startup fails without deleting or overwriting the encrypted index
+- Incompatible schema: archive the old database as `.bak`, then rebuild from the vault
+- Backend identity missing/mismatch: archive the database as `.bak`, discard its checkpoint, and rebuild
 - DB nuked (invalid `since`): `catchUp` errors, clears index, rebuilds from `since: "0"`
 - Volume nuked: no persisted index, full rebuild; auth tokens lost (users re-authenticate)
-- Crash during save: concurrent save guard prevents corruption; next restart rebuilds
+- Crash during catch-up: the last committed SQLite checkpoint resumes the next run
+- Rollback: stop cleanly and start the previous image with the same vault and
+  `DATA_DIR`; the v2 file does not replace or remove the prior release's index
 
 ## Vault Backend (`src/vault-backend.ts`)
 
@@ -148,7 +189,7 @@ Agent connects → /oauth/authorize → password page → /oauth/approve
 | `list_notes` | index (fallback: vault) | — |
 | `list_folders` | index (fallback: vault) | — |
 | `list_tags` | index | — |
-| `search_vault` | index + vault (for snippets) | — |
+| `search_notes` | disk-backed FTS index | — |
 | `get_note_metadata` | vault + index (backlinks) | — |
 | `move_note` | vault | vault + index |
 | `delete_note` | — | vault + index |
@@ -171,3 +212,4 @@ livesync-commonlib is a Deno-style TypeScript library compiled for Node via tsup
 - **FastMCP** — MCP server framework
 - **Hono** — HTTP framework (used by FastMCP, we add OAuth routes)
 - **PouchDB** — CouchDB client (transitive via livesync-commonlib)
+- **better-sqlite3-multiple-ciphers** — synchronous FTS5 and SQLCipher-compatible encrypted index storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Security
+- Harden the encrypted full-text index key derivation with scrypt before HKDF. Search v2 uses a separate encrypted file, preserving the prototype index for rollback.
+- Scope search storage, encryption keys, and CouchDB checkpoints to a stable backend identity instead of `VAULT_NAME`. Unverifiable name-scoped indexes are left intact and rebuilt once; an identity mismatch inside SQLite is archived before rebuilding.
+
+### Features
+- Restore optional full-text note search with heading-level chunks, exact title/alias/path lookup, stemmed BM25 passage search, reciprocal-rank fusion, grouped snippets, and folder/tag/date filters.
+- Consolidate note metadata, tags, links/backlinks, and the CouchDB checkpoint into the SQLite index. Batch checkpoints are atomic, indexing yields between commits, and search responses disclose partial-build status.
+- Make filesystem startup incremental: read only new or mtime-changed bodies, persist same-content mtime changes, and remove deleted entries even when the vault is empty.
+
+### Behavior changes
+- The JSON metadata snapshot (`search-index.json`) is no longer written or read. With `FULL_TEXT_SEARCH=false` there is now no persistence at all: metadata is rebuilt in memory on each startup, and CouchDB mode replays the full `_changes` feed from the beginning every restart.
+- All index-backed read tools label build, catch-up, and error responses as incomplete or stale, including listings, counts, search results, and backlinks.
+
 ## 0.6.3
 
 ### Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM node:22-slim
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+# The encrypted SQLite dependency ships platform-specific prebuilds. npm's
+# implicit node-gyp lifecycle would rebuild it unnecessarily in this slim image.
+RUN npm ci --omit=dev --ignore-scripts
 
 COPY dist/ dist/
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![MCP](https://img.shields.io/badge/MCP-compatible-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![Node](https://img.shields.io/badge/node-22%2B-green.svg)
+![Node](https://img.shields.io/badge/node-22.14%2B%20%7C%2024-green.svg)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5-blue.svg)
 
 Give any AI agent access to your Obsidian vault over MCP. Run it locally against your vault files, or pair it with [Self-hosted LiveSync](https://github.com/vrtmrz/obsidian-livesync) and deploy to the cloud so it works even when your machine is off.
@@ -206,6 +206,7 @@ Set `BASE_URL` to the tunnel URL when using authentication.
 | `list_folders` | List all folders in the vault with note counts — use to discover folder names |
 | `list_tags` | List all tags in the vault with counts — use to discover tags before filtering |
 | `list_notes` | List notes with timestamps. Filter by folder, name, tag, or date. Sort by name or modified. |
+| `search_notes` | Ranked full-text search across titles, aliases, headings, tags, and note bodies, with snippets and folder/tag/date filters |
 | `delete_note` | Delete a note |
 | `move_note` | Move or rename a note — works across folders, creates destination folders automatically |
 | `get_note_metadata` | Get frontmatter, tags, outgoing links, backlinks, size, and timestamps — navigate the knowledge graph |
@@ -249,13 +250,14 @@ Without `MCP_AUTH_TOKEN`, the server runs without authentication — suitable fo
 | `COUCHDB_DATABASE` | CouchDB mode | `obsidian` | CouchDB database name |
 | `COUCHDB_PASSPHRASE` | CouchDB mode | — | LiveSync E2E encryption passphrase (must match plugin setting) |
 | `COUCHDB_OBFUSCATE_PROPERTIES` | CouchDB mode | `false` | Set to `true` if "Obfuscate Properties" is enabled in LiveSync (obfuscates file paths, sizes, dates in the database). For existing vaults the actual setting is auto-detected at startup; this value only decides the format for a brand-new empty database |
-| `VAULT_NAME` | Both | `MyVault` | Vault name (used for deep links and index storage) |
+| `VAULT_NAME` | Both | `MyVault` | Display name used for Obsidian deep links and the established OAuth-token path. Search identity comes from the filesystem root or CouchDB URL + database. |
 | `MCP_AUTH_TOKEN` | Optional | — | Password for authentication |
 | `BASE_URL` | Optional | `http://localhost:PORT` | Public URL (for OAuth callbacks when using a tunnel) |
 | `PORT` | Optional | `8787` | HTTP port |
 | `HOST` | Optional | `0.0.0.0` | Bind address (`127.0.0.1` to restrict to localhost) |
 | `MCP_ALLOWED_HOSTS` | Optional | — | Comma-separated extra `Host` values accepted in no-auth mode (e.g. `192.168.1.5,mybox.local`). No-auth mode rejects any other Host to block browser DNS-rebinding; localhost is always allowed. Ignored when `MCP_AUTH_TOKEN` is set. |
-| `DATA_DIR` | Optional | `~/.obsidian-mcp` | Directory for persisted data (metadata index, auth tokens) |
+| `DATA_DIR` | Optional | `~/.obsidian-mcp` | Directory for the SQLite search index and auth tokens |
+| `FULL_TEXT_SEARCH` | Optional | `auto` | Disk-backed SQLite full-text search: `auto` and `true` enable it; `false` disables it. When `COUCHDB_PASSPHRASE` is set, the local index is encrypted with a backend-specific derived key. Note: `false` also disables index persistence — metadata is rebuilt in memory on every startup, and CouchDB mode replays the full `_changes` feed each time. |
 | `LOG_LEVEL` | Optional | — | Set to `debug` for verbose logging (library logs, change feed, index sync) |
 | `MCP_REFRESH_DAYS` | Optional | `14` | Days before auth session expires |
 | `READ_ONLY` | Optional | `false` | Set to `true` to disable all write tools (`write_note`, `edit_note`, `delete_note`, `move_note`). Only read tools are exposed via MCP. Useful when sharing the server with multiple AI clients and write access should be opt-in. |
@@ -264,6 +266,51 @@ Without `MCP_AUTH_TOKEN`, the server runs without authentication — suitable fo
 | `MCP_INSTRUCTIONS_FILE` | Optional | — | Path to a file (e.g. markdown) whose contents are appended to the MCP `instructions`. Easier than `MCP_INSTRUCTIONS` for multi-line conventions. If both are set, the file wins and `MCP_INSTRUCTIONS` is ignored (with a startup warning). Missing/unreadable file or files larger than 32 KB are fatal startup errors. **Store this file somewhere only the service user can write (e.g. `chmod 600`)** — its contents land in every MCP session's system prompt, so write access to it = prompt-injection access to every client. |
 
 Set `VAULT_PATH` for filesystem mode or `COUCHDB_URL` for CouchDB mode.
+
+`FULL_TEXT_SEARCH=auto` is the upstream default and currently has the same
+enablement behaviour as `true`: both expose `search_notes` and persist the
+SQLite index. `true` does not force encryption; encryption follows the source
+vault. An encrypted LiveSync vault always gets an encrypted index, while a local
+or unencrypted CouchDB vault gets plaintext SQLite. `false` removes
+`search_notes`, keeps metadata only in memory, and leaves any existing index file
+untouched for rollback or later re-enablement.
+
+For LiveSync E2E-encrypted vaults, the full-text index uses SQLCipher-compatible
+AES-256 page encryption with per-page authentication. The CouchDB passphrase is
+first hardened with scrypt, then domain-separated with HKDF into a dedicated index
+key, and is never written to the database. Search v2 uses a separate index file,
+so the previous index remains available if you roll back the Docker tag. Search
+contents are decrypted only while the MCP process is running and unlocked.
+
+Search storage and encryption are scoped to the actual backend (canonical
+`VAULT_PATH`, or credential-free `COUCHDB_URL` plus `COUCHDB_DATABASE`), so two
+backends with the same `VAULT_NAME` cannot share results or a CouchDB checkpoint.
+The index is stored at
+`DATA_DIR/backends/<backend-hash>/full-text-index-v2.sqlite` with owner-only
+permissions. It contains note text and metadata and must be treated as a derived
+vault copy. Encrypted indexes keep SQLite rollback journals and schema backups
+encrypted; local and unencrypted-vault indexes do not.
+
+The first upgrade from the name-scoped prototype performs a clean rebuild and
+leaves the old index intact because its backend ownership cannot be verified.
+Filesystem restarts read only new or mtime-changed note bodies, remove deleted
+paths, and persist newer mtimes even when content is unchanged. Index-backed
+tools warn while a build or catch-up can make results, counts, or backlinks
+incomplete.
+
+Changing `VAULT_PATH`, the credential-free CouchDB URL, or `COUCHDB_DATABASE`
+selects a different backend directory and rebuilds without reusing another
+vault's checkpoint. A changed or wrong passphrase fails startup without
+overwriting the encrypted index. An incompatible schema or embedded backend
+identity is renamed to a timestamped `.bak` before a clean rebuild. A
+plaintext-to-encrypted upgrade re-keys the active SQLite file, but old snapshots
+or backups may still retain plaintext and must be expired separately.
+
+To roll back, stop the candidate cleanly and start the previous image against
+the same vault and persistent `DATA_DIR`. Search v2 uses a separate file and
+does not delete the prior release's index. Do not delete or migrate either index
+until the previous image has opened successfully; a rebuild affects only the
+derived index, never the source vault.
 
 ---
 
@@ -297,7 +344,13 @@ Set transport to **Streamable HTTP**, enter `http://localhost:8787/mcp`, and con
 - **No conflict resolution.** If an agent and Obsidian edit the same note simultaneously, last write wins.
 - **Text only.** Binary attachments are not exposed through MCP tools.
 - **Deep links depend on the client.** Obsidian `obsidian://` deep links are included in every tool response. They work on Claude Mobile and in browsers, but some clients (Claude Desktop) may not render them as clickable links.
-- **Node 22+ required.**
+- **Node 22.14+ or Node 24 required.** Node 22.13 crashes inside the native
+  SQLite dependency. The dependency must also match the runtime platform and
+  architecture.
+- **Source checkouts should use `npm ci --ignore-scripts`.** The SQLite package
+  bundles Linux, macOS, and Windows prebuilds, but npm otherwise invokes its
+  unnecessary implicit `node-gyp rebuild`; compiling from source requires
+  Python, `make`, and a C++ compiler.
 - **Setup script requires bash.** The `deploy/setup.sh` script works on macOS and Linux. On Windows, use WSL or Git Bash.
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,13 +62,38 @@ The server implements a self-contained OAuth 2.1 authorization server with PKCE.
 - **E2E encryption supported** — when `COUCHDB_PASSPHRASE` is set, the server decrypts and encrypts vault data using the same scheme as Self-hosted LiveSync. Data is encrypted at rest in CouchDB.
 - **Text only** — binary attachments are not exposed through MCP tools, reducing the attack surface.
 - **Search result cap** — search results are limited to 50 matches, preventing large responses from exhausting memory or leaking excessive content.
-- **Search index encryption** — the persisted search metadata (paths and timestamps) is encrypted at rest using `COUCHDB_PASSPHRASE` when set. Note content is not persisted — only the FlexSearch tokenized index lives in memory (lost on full restart, rebuilt from vault). Content snippets are fetched on demand from the vault, not cached.
+- **Search content is persisted** — full-text search stores note paths, titles,
+  aliases, tags, links, modification times, content hashes, heading-level note
+  text, and the CouchDB checkpoint in SQLite. Treat the index as a derived copy
+  of the vault and include it in the same access-control and backup policy.
+- **Encrypted-vault indexes are encrypted** — when CouchDB mode uses
+  `COUCHDB_PASSPHRASE`, scrypt hardens the passphrase and HKDF derives a
+  backend-specific key for SQLCipher-compatible AES-256 page encryption. The
+  index key is distinct from LiveSync document keys and is never persisted.
+- **Local and unencrypted-vault indexes are plaintext by design** — filesystem
+  vaults and CouchDB vaults without a passphrase use ordinary SQLite because
+  their source notes are already plaintext at rest. Set `FULL_TEXT_SEARCH=false`
+  if any derived full-text persistence is unacceptable; metadata and search are
+  then rebuilt in memory and full-text search is not exposed.
+- **Private index artifacts** — the index database is created with mode `0600`,
+  temporary SQLite tables stay in memory, and rollback-journal pages remain
+  encrypted for encrypted indexes. Incompatible-schema and backend-mismatch
+  backups retain the source index's encryption. Tests inspect the database, an
+  active rollback journal, migration outputs, and encrypted schema backups for
+  plaintext note markers and owner-only permissions.
+- **Migration limitation** — upgrading an existing plaintext search index uses
+  an in-place SQLite re-key. The active files are encrypted and permissioned
+  before startup completes, but old filesystem snapshots, external backups, or
+  recoverable deleted blocks may still contain the former plaintext copy. Remove
+  those according to the storage provider's retention and secure-erasure model.
 
 ---
 
 ## Graceful shutdown
 
-- The server handles `SIGTERM` and `SIGINT` signals, cleanly closing the CouchDB connection before exiting. Prevents data corruption on container stop.
+- The server handles `SIGTERM` and `SIGINT`, rolls back any uncommitted search
+  batch, closes SQLite, saves OAuth state, and closes the CouchDB connection
+  before exiting.
 
 ---
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,86 @@
+# Search v2 benchmark
+
+This benchmark measures the disk-backed search index with a deterministic
+synthetic corpus. Each note has an alias, two tags, a link, and three
+heading-level chunks. Query samples cover exact title, exact alias, rare body
+text, folder-filtered body text, an exact phrase, and a broad all-word query.
+
+## Reproduce
+
+Install dependencies under Node 22.14+ or Node 24, then run:
+
+```bash
+BENCH_NOTES=100000 BENCH_QUERIES=120 npm run benchmark:search
+BENCH_NOTES=100000 BENCH_QUERIES=120 BENCH_ENCRYPTED=true npm run benchmark:search
+```
+
+Set `BENCH_OUTPUT` to save the emitted JSON. The committed artifacts were
+produced with the repository mounted into `node:22-slim` and networking
+disabled, for example:
+
+```bash
+docker run --rm --network none \
+  -e BENCH_NOTES=100000 \
+  -e BENCH_QUERIES=120 \
+  -e BENCH_ENCRYPTED=true \
+  -e BENCH_OUTPUT=/workspace/benchmarks/results/node22-amd64-100000-encrypted.json \
+  -v "$PWD:/workspace" -w /workspace node:22-slim \
+  npm run benchmark:search
+```
+
+## Reference results
+
+Captured on 2026-08-27 with Node 22.23.2, Linux x64 under WSL2, an AMD Ryzen 7
+7800X3D, 16 logical CPUs, and no container CPU or memory limit. Values are one
+run per cell; use the JSON artifacts for per-query-class percentiles.
+
+| Notes | Index | Build (s) | Notes/s | Query p95 (ms) | Update p95 (ms) | Index (MiB) | RSS (MiB) |
+|---:|:---|---:|---:|---:|---:|---:|---:|
+| 10,000 | plaintext | 2.20 | 4,547 | 23.22 | 8.52 | 19.39 | 152.93 |
+| 10,000 | encrypted | 2.50 | 4,000 | 23.23 | 9.30 | 20.02 | 135.07 |
+| 50,000 | plaintext | 14.12 | 3,541 | 98.60 | 9.15 | 99.90 | 240.45 |
+| 50,000 | encrypted | 17.65 | 2,834 | 176.81 | 10.10 | 103.63 | 240.52 |
+| 100,000 | plaintext | 29.20 | 3,424 | 206.82 | 9.00 | 198.95 | 283.98 |
+| 100,000 | encrypted | 38.67 | 2,586 | 384.28 | 10.54 | 206.47 | 284.64 |
+
+At 100,000 notes, encryption reduced build throughput by about 24%, increased
+the aggregate query p95 by about 86%, and increased index size by about 3.8%.
+RSS was effectively unchanged. Phrase and broad queries are the slowest classes;
+exact and rare-term queries remain materially faster in the raw artifacts.
+
+## Regression thresholds
+
+For the reference 100,000-note corpus on comparable x64 hardware, investigate a
+change when any of these are true:
+
+- build throughput falls below 2,000 notes/s;
+- aggregate query p95 exceeds 250 ms for plaintext or 450 ms for encrypted;
+- update p95 exceeds 20 ms;
+- RSS exceeds 350 MiB;
+- the main index exceeds 225 MiB; or
+- a metric regresses by more than 20% from the matching committed baseline,
+  even if it remains below the absolute ceiling.
+
+These are regression budgets, not universal service-level objectives. Real PKBs
+vary in note length, language, heading density, storage latency, and query mix.
+Run the harness more than once before treating a small difference as signal.
+
+## FlexSearch context
+
+The historical FlexSearch implementation has no committed, same-corpus raw
+artifact, so this benchmark does not claim a direct latency comparison. Project
+history records that its persisted 53 MiB index caused out-of-memory failures on
+load and that full-text search was removed. Search v2 instead demonstrates a
+bounded ~285 MiB process RSS at 100,000 synthetic notes, keeps note bodies out of
+the JavaScript heap, persists incremental SQLite state, and resumes from a
+checkpoint. Those are architectural comparisons; they are not an apples-to-
+apples performance result.
+
+## Raw artifacts
+
+- `results/node22-amd64-10000-plaintext.json`
+- `results/node22-amd64-10000-encrypted.json`
+- `results/node22-amd64-50000-plaintext.json`
+- `results/node22-amd64-50000-encrypted.json`
+- `results/node22-amd64-100000-plaintext.json`
+- `results/node22-amd64-100000-encrypted.json`

--- a/benchmarks/results/node22-amd64-10000-encrypted.json
+++ b/benchmarks/results/node22-amd64-10000-encrypted.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-27T06:46:55.273Z",
+  "runtime": {
+    "node": "v22.23.2",
+    "platform": "linux",
+    "architecture": "x64",
+    "kernel": "6.6.87.2-microsoft-standard-WSL2",
+    "cpuModel": "AMD Ryzen 7 7800X3D 8-Core Processor",
+    "logicalCpuCount": 16,
+    "hostMemoryMiB": 15426.18,
+    "cgroupMemoryLimitBytes": null,
+    "cgroupCpuLimit": "max 100000"
+  },
+  "encrypted": true,
+  "notes": 10000,
+  "chunks": 29900,
+  "queryRuns": 120,
+  "updateRuns": 50,
+  "buildSeconds": 2.5,
+  "notesPerSecond": 4000,
+  "queryP50Ms": 5.62,
+  "queryP95Ms": 23.23,
+  "queryP99Ms": 24.03,
+  "updateP95Ms": 9.3,
+  "indexMiB": 20.02,
+  "rssMiB": 135.07,
+  "maxRssMiB": 135.07,
+  "queryClasses": {
+    "exact-title": {
+      "p50Ms": 5.62,
+      "p95Ms": 6.6
+    },
+    "exact-alias": {
+      "p50Ms": 4.88,
+      "p95Ms": 5.3
+    },
+    "rare-passage": {
+      "p50Ms": 4.61,
+      "p95Ms": 5.17
+    },
+    "filtered-passage": {
+      "p50Ms": 5.51,
+      "p95Ms": 6.35
+    },
+    "phrase": {
+      "p50Ms": 20.45,
+      "p95Ms": 21.61
+    },
+    "broad-passage": {
+      "p50Ms": 23.19,
+      "p95Ms": 24.03
+    }
+  }
+}

--- a/benchmarks/results/node22-amd64-10000-plaintext.json
+++ b/benchmarks/results/node22-amd64-10000-plaintext.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-27T06:46:38.300Z",
+  "runtime": {
+    "node": "v22.23.2",
+    "platform": "linux",
+    "architecture": "x64",
+    "kernel": "6.6.87.2-microsoft-standard-WSL2",
+    "cpuModel": "AMD Ryzen 7 7800X3D 8-Core Processor",
+    "logicalCpuCount": 16,
+    "hostMemoryMiB": 15426.18,
+    "cgroupMemoryLimitBytes": null,
+    "cgroupCpuLimit": "max 100000"
+  },
+  "encrypted": false,
+  "notes": 10000,
+  "chunks": 29900,
+  "queryRuns": 120,
+  "updateRuns": 50,
+  "buildSeconds": 2.2,
+  "notesPerSecond": 4547,
+  "queryP50Ms": 5.69,
+  "queryP95Ms": 23.22,
+  "queryP99Ms": 23.9,
+  "updateP95Ms": 8.52,
+  "indexMiB": 19.39,
+  "rssMiB": 152.93,
+  "maxRssMiB": 152.93,
+  "queryClasses": {
+    "exact-title": {
+      "p50Ms": 5.77,
+      "p95Ms": 6.22
+    },
+    "exact-alias": {
+      "p50Ms": 5.14,
+      "p95Ms": 5.4
+    },
+    "rare-passage": {
+      "p50Ms": 4.77,
+      "p95Ms": 5.11
+    },
+    "filtered-passage": {
+      "p50Ms": 5.45,
+      "p95Ms": 6.17
+    },
+    "phrase": {
+      "p50Ms": 20.86,
+      "p95Ms": 21.32
+    },
+    "broad-passage": {
+      "p50Ms": 23,
+      "p95Ms": 23.9
+    }
+  }
+}

--- a/benchmarks/results/node22-amd64-100000-encrypted.json
+++ b/benchmarks/results/node22-amd64-100000-encrypted.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-27T06:50:43.895Z",
+  "runtime": {
+    "node": "v22.23.2",
+    "platform": "linux",
+    "architecture": "x64",
+    "kernel": "6.6.87.2-microsoft-standard-WSL2",
+    "cpuModel": "AMD Ryzen 7 7800X3D 8-Core Processor",
+    "logicalCpuCount": 16,
+    "hostMemoryMiB": 15426.18,
+    "cgroupMemoryLimitBytes": null,
+    "cgroupCpuLimit": "max 100000"
+  },
+  "encrypted": true,
+  "notes": 100000,
+  "chunks": 299900,
+  "queryRuns": 120,
+  "updateRuns": 50,
+  "buildSeconds": 38.67,
+  "notesPerSecond": 2586,
+  "queryP50Ms": 155.37,
+  "queryP95Ms": 384.28,
+  "queryP99Ms": 388.01,
+  "updateP95Ms": 10.54,
+  "indexMiB": 206.47,
+  "rssMiB": 284.64,
+  "maxRssMiB": 284.64,
+  "queryClasses": {
+    "exact-title": {
+      "p50Ms": 144.57,
+      "p95Ms": 153.82
+    },
+    "exact-alias": {
+      "p50Ms": 126.5,
+      "p95Ms": 131.25
+    },
+    "rare-passage": {
+      "p50Ms": 120.12,
+      "p95Ms": 131.48
+    },
+    "filtered-passage": {
+      "p50Ms": 194.17,
+      "p95Ms": 201.02
+    },
+    "phrase": {
+      "p50Ms": 364.27,
+      "p95Ms": 377.92
+    },
+    "broad-passage": {
+      "p50Ms": 377.73,
+      "p95Ms": 388.01
+    }
+  }
+}

--- a/benchmarks/results/node22-amd64-100000-plaintext.json
+++ b/benchmarks/results/node22-amd64-100000-plaintext.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-27T06:49:20.303Z",
+  "runtime": {
+    "node": "v22.23.2",
+    "platform": "linux",
+    "architecture": "x64",
+    "kernel": "6.6.87.2-microsoft-standard-WSL2",
+    "cpuModel": "AMD Ryzen 7 7800X3D 8-Core Processor",
+    "logicalCpuCount": 16,
+    "hostMemoryMiB": 15426.18,
+    "cgroupMemoryLimitBytes": null,
+    "cgroupCpuLimit": "max 100000"
+  },
+  "encrypted": false,
+  "notes": 100000,
+  "chunks": 299900,
+  "queryRuns": 120,
+  "updateRuns": 50,
+  "buildSeconds": 29.2,
+  "notesPerSecond": 3424,
+  "queryP50Ms": 77.14,
+  "queryP95Ms": 206.82,
+  "queryP99Ms": 237.52,
+  "updateP95Ms": 9,
+  "indexMiB": 198.95,
+  "rssMiB": 283.98,
+  "maxRssMiB": 283.98,
+  "queryClasses": {
+    "exact-title": {
+      "p50Ms": 77.78,
+      "p95Ms": 94.06
+    },
+    "exact-alias": {
+      "p50Ms": 68.01,
+      "p95Ms": 79.44
+    },
+    "rare-passage": {
+      "p50Ms": 63.62,
+      "p95Ms": 76.39
+    },
+    "filtered-passage": {
+      "p50Ms": 73.79,
+      "p95Ms": 83.17
+    },
+    "phrase": {
+      "p50Ms": 187.81,
+      "p95Ms": 205.62
+    },
+    "broad-passage": {
+      "p50Ms": 197.26,
+      "p95Ms": 215.65
+    }
+  }
+}

--- a/benchmarks/results/node22-amd64-50000-encrypted.json
+++ b/benchmarks/results/node22-amd64-50000-encrypted.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-27T06:48:11.409Z",
+  "runtime": {
+    "node": "v22.23.2",
+    "platform": "linux",
+    "architecture": "x64",
+    "kernel": "6.6.87.2-microsoft-standard-WSL2",
+    "cpuModel": "AMD Ryzen 7 7800X3D 8-Core Processor",
+    "logicalCpuCount": 16,
+    "hostMemoryMiB": 15426.18,
+    "cgroupMemoryLimitBytes": null,
+    "cgroupCpuLimit": "max 100000"
+  },
+  "encrypted": true,
+  "notes": 50000,
+  "chunks": 149900,
+  "queryRuns": 120,
+  "updateRuns": 50,
+  "buildSeconds": 17.65,
+  "notesPerSecond": 2834,
+  "queryP50Ms": 66.88,
+  "queryP95Ms": 176.81,
+  "queryP99Ms": 179.76,
+  "updateP95Ms": 10.1,
+  "indexMiB": 103.63,
+  "rssMiB": 240.52,
+  "maxRssMiB": 241.22,
+  "queryClasses": {
+    "exact-title": {
+      "p50Ms": 63.29,
+      "p95Ms": 66.13
+    },
+    "exact-alias": {
+      "p50Ms": 30.17,
+      "p95Ms": 32.76
+    },
+    "rare-passage": {
+      "p50Ms": 26.78,
+      "p95Ms": 29.9
+    },
+    "filtered-passage": {
+      "p50Ms": 85.21,
+      "p95Ms": 89.1
+    },
+    "phrase": {
+      "p50Ms": 168.37,
+      "p95Ms": 171.58
+    },
+    "broad-passage": {
+      "p50Ms": 176.11,
+      "p95Ms": 179.76
+    }
+  }
+}

--- a/benchmarks/results/node22-amd64-50000-plaintext.json
+++ b/benchmarks/results/node22-amd64-50000-plaintext.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-27T06:47:28.936Z",
+  "runtime": {
+    "node": "v22.23.2",
+    "platform": "linux",
+    "architecture": "x64",
+    "kernel": "6.6.87.2-microsoft-standard-WSL2",
+    "cpuModel": "AMD Ryzen 7 7800X3D 8-Core Processor",
+    "logicalCpuCount": 16,
+    "hostMemoryMiB": 15426.18,
+    "cgroupMemoryLimitBytes": null,
+    "cgroupCpuLimit": "max 100000"
+  },
+  "encrypted": false,
+  "notes": 50000,
+  "chunks": 149900,
+  "queryRuns": 120,
+  "updateRuns": 50,
+  "buildSeconds": 14.12,
+  "notesPerSecond": 3541,
+  "queryP50Ms": 33.55,
+  "queryP95Ms": 98.6,
+  "queryP99Ms": 104.2,
+  "updateP95Ms": 9.15,
+  "indexMiB": 99.9,
+  "rssMiB": 240.45,
+  "maxRssMiB": 240.45,
+  "queryClasses": {
+    "exact-title": {
+      "p50Ms": 34.25,
+      "p95Ms": 38.82
+    },
+    "exact-alias": {
+      "p50Ms": 28.4,
+      "p95Ms": 32.99
+    },
+    "rare-passage": {
+      "p50Ms": 26.55,
+      "p95Ms": 28.2
+    },
+    "filtered-passage": {
+      "p50Ms": 32.86,
+      "p95Ms": 34.35
+    },
+    "phrase": {
+      "p50Ms": 88.07,
+      "p95Ms": 90.12
+    },
+    "broad-passage": {
+      "p50Ms": 97.12,
+      "p95Ms": 104.2
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.6.3",
             "license": "MIT",
             "dependencies": {
+                "better-sqlite3-multiple-ciphers": "^13.0.3",
                 "diff-match-patch": "^1.0.5",
                 "fastmcp": "^3.34.0",
                 "fflate": "^0.8.2",
@@ -24,6 +25,7 @@
                 "pouchdb-utils": "^9.0.0",
                 "transform-pouch": "^2.0.0",
                 "xxhash-wasm": "^1.0.2",
+                "yaml": "^2.9.0",
                 "zod": "^3"
             },
             "bin": {
@@ -36,7 +38,7 @@
                 "typescript": "^5"
             },
             "engines": {
-                "node": ">=22"
+                "node": "^22.14.0 || ^24.0.0"
             }
         },
         "node_modules/@borewit/text-codec": {
@@ -1132,6 +1134,18 @@
             "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/better-sqlite3-multiple-ciphers": {
+            "version": "13.0.3",
+            "resolved": "https://registry.npmjs.org/better-sqlite3-multiple-ciphers/-/better-sqlite3-multiple-ciphers-13.0.3.tgz",
+            "integrity": "sha512-UYabM82r1J84TLWc/SszoHs6XopWpl/2HCg3Nui1JUaFXg/VLswzkPowYiRhK/4CftI8dgtikwyZQecMldrGxQ==",
+            "license": "MIT",
+            "dependencies": {
+                "node-addon-api": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/body-parser": {
@@ -2673,6 +2687,15 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/node-addon-api": {
+            "version": "8.9.2",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+            "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18 || ^20 || >= 21"
+            }
+        },
         "node_modules/node-fetch": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
@@ -4093,6 +4116,21 @@
             "license": "ISC",
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "ai"
     ],
     "engines": {
-        "node": ">=22"
+        "node": "^22.14.0 || ^24.0.0"
     },
     "bin": {
         "obsidian-sync-mcp": "dist/main.js"
@@ -34,10 +34,12 @@
         "start": "node dist/main.js",
         "dev": "tsx src/main.ts",
         "test": "node --import tsx --test 'src/**/*.test.ts'",
+        "benchmark:search": "node --import tsx scripts/benchmark-search.ts",
         "test:e2e": "node --import tsx --test test/e2e.test.ts",
         "test:couchdb": "tsup test/couchdb-obfuscation.e2e.ts --out-dir .harness-tmp && node .harness-tmp/couchdb-obfuscation.e2e.js"
     },
     "dependencies": {
+        "better-sqlite3-multiple-ciphers": "^13.0.3",
         "diff-match-patch": "^1.0.5",
         "fastmcp": "^3.34.0",
         "fflate": "^0.8.2",
@@ -53,6 +55,7 @@
         "pouchdb-utils": "^9.0.0",
         "transform-pouch": "^2.0.0",
         "xxhash-wasm": "^1.0.2",
+        "yaml": "^2.9.0",
         "zod": "^3"
     },
     "devDependencies": {

--- a/scripts/benchmark-search.ts
+++ b/scripts/benchmark-search.ts
@@ -1,0 +1,150 @@
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { arch, cpus, platform, release, tmpdir, totalmem } from "node:os";
+import { dirname, join } from "node:path";
+import { deriveFullTextIndexKey, FullTextIndex } from "../src/full-text-search.js";
+
+const noteCount = Number.parseInt(process.env.BENCH_NOTES ?? "50000", 10);
+const queryRuns = Number.parseInt(process.env.BENCH_QUERIES ?? "120", 10);
+const outputPath = process.env.BENCH_OUTPUT;
+if (!Number.isSafeInteger(noteCount) || noteCount < 1) throw new Error("BENCH_NOTES must be a positive integer.");
+if (!Number.isSafeInteger(queryRuns) || queryRuns < 6) throw new Error("BENCH_QUERIES must be an integer of at least 6.");
+const directory = await mkdtemp(join(tmpdir(), "obsidian-search-bench-"));
+const databasePath = join(directory, "search.sqlite");
+
+function percentile(values: number[], fraction: number): number {
+    const sorted = [...values].sort((left, right) => left - right);
+    return sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * fraction) - 1))];
+}
+
+async function readCgroupValue(path: string): Promise<string | undefined> {
+    try {
+        const value = (await readFile(path, "utf8")).trim();
+        return value === "max" ? undefined : value;
+    } catch {
+        return undefined;
+    }
+}
+
+try {
+    const encrypted = process.env.BENCH_ENCRYPTED === "true";
+    const encryptionKey = encrypted
+        ? deriveFullTextIndexKey("benchmark passphrase", "benchmark-vault")
+        : undefined;
+    const index = await FullTextIndex.open(databasePath, { encryptionKey });
+    encryptionKey?.fill(0);
+    const started = performance.now();
+    for (let offset = 0; offset < noteCount; offset += 500) {
+        index.beginBatch();
+        try {
+            for (let note = offset; note < Math.min(offset + 500, noteCount); note++) {
+                index.update(
+                    `areas/area-${note % 100}/project-${note}.md`,
+                    `---
+aliases: ["Initiative ${note}"]
+tags: [project, area-${note % 100}]
+---
+# Project ${note}
+
+Background for project ${note}. This note records durable PKB context and ownership.
+
+## Provider recovery
+
+Stream provider recovery evidence marker${note} and playback edge observations.
+
+## Decisions
+
+The team selected bounded retries and visible recovery status. See [[Project ${(note + 1) % noteCount}]].`,
+                    note,
+                );
+            }
+            index.commitBatch();
+        } catch (error) {
+            index.rollbackBatch();
+            throw error;
+        }
+    }
+    const buildMs = performance.now() - started;
+
+    const queries = [
+        { label: "exact-title", options: { query: `Project ${Math.floor(noteCount * 0.84)}` } },
+        { label: "exact-alias", options: { query: `Initiative ${Math.floor(noteCount * 0.63)}` } },
+        { label: "rare-passage", options: { query: `marker${Math.floor(noteCount * 0.42)}` } },
+        { label: "filtered-passage", options: { query: "provider recovery", folder: "areas/area-42" } },
+        { label: "phrase", options: { query: "bounded retries", mode: "phrase" as const } },
+        { label: "broad-passage", options: { query: "bounded retries visible status" } },
+    ];
+    for (const query of queries) index.search({ ...query.options, limit: 20 });
+
+    const latencies: number[] = [];
+    const byQuery = new Map<string, number[]>();
+    for (let run = 0; run < queryRuns; run++) {
+        const query = queries[run % queries.length];
+        const queryStart = performance.now();
+        index.search({ ...query.options, limit: 20 });
+        const elapsed = performance.now() - queryStart;
+        latencies.push(elapsed);
+        const samples = byQuery.get(query.label) ?? [];
+        samples.push(elapsed);
+        byQuery.set(query.label, samples);
+    }
+    const updateLatencies: number[] = [];
+    for (let run = 0; run < 50; run++) {
+        const note = Math.floor(noteCount / 2) + run;
+        const updateStart = performance.now();
+        index.update(
+            `areas/area-${note % 100}/project-${note}.md`,
+            `# Project ${note}\n\n## Update\nIncremental recovery update ${run}.`,
+            noteCount + run,
+        );
+        updateLatencies.push(performance.now() - updateStart);
+    }
+    const memory = process.memoryUsage();
+    const usage = process.resourceUsage();
+    const notes = index.size;
+    const chunks = index.chunkCount;
+    index.close();
+    const bytes = (await stat(databasePath)).size;
+    const cgroupMemoryBytes = await readCgroupValue("/sys/fs/cgroup/memory.max");
+    const cgroupCpu = await readCgroupValue("/sys/fs/cgroup/cpu.max");
+    const result = {
+        schemaVersion: 1,
+        generatedAt: new Date().toISOString(),
+        runtime: {
+            node: process.version,
+            platform: platform(),
+            architecture: arch(),
+            kernel: release(),
+            cpuModel: cpus()[0]?.model ?? "unknown",
+            logicalCpuCount: cpus().length,
+            hostMemoryMiB: Number((totalmem() / 1024 / 1024).toFixed(2)),
+            cgroupMemoryLimitBytes: cgroupMemoryBytes ? Number(cgroupMemoryBytes) : null,
+            cgroupCpuLimit: cgroupCpu ?? null,
+        },
+        encrypted,
+        notes,
+        chunks,
+        queryRuns,
+        updateRuns: updateLatencies.length,
+        buildSeconds: Number((buildMs / 1000).toFixed(2)),
+        notesPerSecond: Math.round(noteCount / (buildMs / 1000)),
+        queryP50Ms: Number(percentile(latencies, 0.5).toFixed(2)),
+        queryP95Ms: Number(percentile(latencies, 0.95).toFixed(2)),
+        queryP99Ms: Number(percentile(latencies, 0.99).toFixed(2)),
+        updateP95Ms: Number(percentile(updateLatencies, 0.95).toFixed(2)),
+        indexMiB: Number((bytes / 1024 / 1024).toFixed(2)),
+        rssMiB: Number((memory.rss / 1024 / 1024).toFixed(2)),
+        maxRssMiB: Number((usage.maxRSS / 1024).toFixed(2)),
+        queryClasses: Object.fromEntries([...byQuery].map(([label, samples]) => [label, {
+            p50Ms: Number(percentile(samples, 0.5).toFixed(2)),
+            p95Ms: Number(percentile(samples, 0.95).toFixed(2)),
+        }])),
+    };
+    const rendered = `${JSON.stringify(result, null, 2)}\n`;
+    if (outputPath) {
+        await mkdir(dirname(outputPath), { recursive: true });
+        await writeFile(outputPath, rendered, "utf8");
+    }
+    process.stdout.write(rendered);
+} finally {
+    await rm(directory, { recursive: true, force: true });
+}

--- a/src/full-text-search.test.ts
+++ b/src/full-text-search.test.ts
@@ -394,6 +394,34 @@ Provider recovery continues here with a resilience signal.`,
             name.startsWith("backend-identity.sqlite.backend-mismatch-") && name.endsWith(".bak")));
     });
 
+    it("preserves backend identity across clear() so a rebuilt index is not archived on reopen", async () => {
+        const path = join(tmpDir, "clear-identity.sqlite");
+        const first = await FullTextIndex.open(path, { backendIdentity: "backend-a" });
+        first.update("before.md", "content before the rebuild", 100);
+        // Simulate the CouchDB catch-up fallback: clear the corpus, then rebuild
+        // from scratch against the same backend.
+        first.clear();
+        first.update("after.md", "content after the rebuild", 200);
+        first.checkpoint = "rebuilt-checkpoint";
+        first.close();
+
+        const second = await FullTextIndex.open(path, { backendIdentity: "backend-a" });
+        try {
+            assert.equal(second.recreatedForIdentityMismatch, false);
+            assert.equal(second.size, 1);
+            assert.deepEqual(
+                second.search({ query: "after" }).map((r) => r.path),
+                ["after.md"],
+            );
+        } finally {
+            second.close();
+        }
+        // The rebuilt index must not have been archived as an identity mismatch.
+        const names = await readdir(tmpDir);
+        assert.ok(!names.some((name) =>
+            name.startsWith("clear-identity.sqlite.backend-mismatch-") && name.endsWith(".bak")));
+    });
+
     it("persists a newer mtime even when note content is unchanged", async () => {
         const index = await FullTextIndex.open(":memory:");
         try {

--- a/src/full-text-search.test.ts
+++ b/src/full-text-search.test.ts
@@ -1,0 +1,594 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm, stat } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+    buildFtsQuery,
+    deriveFullTextIndexKey,
+    deriveLegacyFullTextIndexKey,
+    deriveSearchBackendId,
+    FullTextIndex,
+    resolveFullTextSearchSetting,
+    searchIndexStoragePaths,
+} from "./full-text-search.js";
+
+let tmpDir: string;
+
+before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "full-text-search-test-"));
+});
+
+after(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("full-text search configuration", () => {
+    it("enables search and encrypts indexes for encrypted vaults by default", () => {
+        assert.deepEqual(resolveFullTextSearchSetting(undefined, false), {
+            enabled: true,
+            encryptIndex: false,
+        });
+        assert.deepEqual(resolveFullTextSearchSetting(undefined, true), {
+            enabled: true,
+            encryptIndex: true,
+        });
+    });
+
+    it("supports explicit enable and disable without weakening encryption", () => {
+        assert.deepEqual(resolveFullTextSearchSetting("true", true), {
+            enabled: true,
+            encryptIndex: true,
+        });
+        assert.equal(resolveFullTextSearchSetting("false", false).enabled, false);
+        assert.equal(resolveFullTextSearchSetting("false", true).encryptIndex, false);
+    });
+
+    it("derives stable, password-hardened, vault-specific index keys", () => {
+        const first = deriveFullTextIndexKey("passphrase", "vault-a");
+        const again = deriveFullTextIndexKey("passphrase", "vault-a");
+        const otherVault = deriveFullTextIndexKey("passphrase", "vault-b");
+        const legacy = deriveLegacyFullTextIndexKey("passphrase", "vault-a");
+        assert.equal(first.length, 32);
+        assert.deepEqual(first, again);
+        assert.notDeepEqual(first, otherVault);
+        assert.notDeepEqual(first, legacy);
+    });
+
+    it("scopes storage identity to the backend rather than the display vault name", () => {
+        const localA = deriveSearchBackendId({ kind: "filesystem", location: "/vault/a" });
+        const localAWindows = deriveSearchBackendId({ kind: "filesystem", location: "\\vault\\a\\" });
+        const localB = deriveSearchBackendId({ kind: "filesystem", location: "/vault/b" });
+        const remote = deriveSearchBackendId({
+            kind: "couchdb",
+            url: "https://user:secret@DB.EXAMPLE.test/root/?ignored=yes",
+            database: "obsidian",
+        });
+        const remoteWithoutCredentials = deriveSearchBackendId({
+            kind: "couchdb",
+            url: "https://db.example.test/root",
+            database: "obsidian",
+        });
+        assert.equal(localA, localAWindows);
+        assert.notEqual(localA, localB);
+        assert.equal(remote, remoteWithoutCredentials);
+        assert.notEqual(remote, deriveSearchBackendId({
+            kind: "couchdb",
+            url: "https://db.example.test/root",
+            database: "another-vault",
+        }));
+
+        const pathsA = searchIndexStoragePaths("/data", localA, "Shared Name");
+        const pathsB = searchIndexStoragePaths("/data", localB, "Shared Name");
+        assert.notEqual(pathsA.indexPath, pathsB.indexPath);
+        assert.equal(pathsA.legacyIndexPath, pathsB.legacyIndexPath);
+        assert.notEqual(pathsA.indexPath, pathsA.legacyIndexPath);
+    });
+
+    it("rejects ambiguous configuration", () => {
+        assert.throws(
+            () => resolveFullTextSearchSetting("yes", false),
+            /FULL_TEXT_SEARCH/,
+        );
+    });
+});
+
+describe("FTS query construction", () => {
+    it("quotes user input instead of accepting raw FTS operators", () => {
+        assert.equal(buildFtsQuery("recovery OR provider"), '"recovery" AND "OR" AND "provider"');
+        assert.equal(buildFtsQuery("recovery provider", "any"), '"recovery" OR "provider"');
+        assert.equal(buildFtsQuery("recovery provider", "phrase"), '"recovery provider"');
+    });
+
+    it("rejects punctuation-only input", () => {
+        assert.throws(() => buildFtsQuery("---"), /letter or number/);
+    });
+});
+
+describe("FullTextIndex", () => {
+    it("ranks title matches above body-only matches and returns snippets", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            index.update(
+                "body-only.md",
+                "# Ordinary note\n\nThis body discusses provider recovery behavior.",
+                100,
+            );
+            index.update(
+                "recovery-design.md",
+                "# Recovery design\n\nA short architecture note.",
+                200,
+            );
+
+            const results = index.search({ query: "recovery" });
+            assert.equal(results.length, 2);
+            assert.equal(results[0].path, "recovery-design.md");
+            assert.match(results[0].snippet, /\*\*Recovery\*\*/i);
+        } finally {
+            index.close();
+        }
+    });
+
+    it("ranks exact filenames and paths and enforces the result limit", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            index.update("projects/provider-recovery.md", "# Unrelated heading\n\nOrdinary body.", 100);
+            index.update("provider-recovery-notes.md", "# Provider recovery notes\n\nOrdinary body.", 200);
+            index.update("body.md", "This body mentions provider recovery.", 300);
+
+            const filename = index.search({ query: "provider recovery", limit: 1 });
+            assert.equal(filename.length, 1);
+            assert.equal(filename[0].path, "projects/provider-recovery.md");
+            assert.equal(filename[0].matchedBy, "exact");
+
+            const path = index.search({ query: "projects provider recovery" });
+            assert.equal(path[0].path, "projects/provider-recovery.md");
+            assert.equal(path[0].matchedBy, "exact");
+        } finally {
+            index.close();
+        }
+    });
+
+    it("supports all, any, and phrase modes", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            index.update("both.md", "provider recovery", 100);
+            index.update("provider.md", "provider latency", 100);
+            index.update("reversed.md", "recovery from the provider", 100);
+
+            assert.deepEqual(
+                index.search({ query: "provider recovery" }).map((r) => r.path).sort(),
+                ["both.md", "reversed.md"],
+            );
+            assert.equal(index.search({ query: "provider recovery", mode: "any" }).length, 3);
+            assert.deepEqual(
+                index.search({ query: "provider recovery", mode: "phrase" }).map((r) => r.path),
+                ["both.md"],
+            );
+        } finally {
+            index.close();
+        }
+    });
+
+    it("normalizes Unicode and applies English stemming", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            index.update("unicode.md", "# Café notes\n\nThe runners were running daily.", 100);
+
+            assert.deepEqual(index.search({ query: "cafe" }).map((r) => r.path), ["unicode.md"]);
+            assert.deepEqual(index.search({ query: "run" }).map((r) => r.path), ["unicode.md"]);
+        } finally {
+            index.close();
+        }
+    });
+
+    it("filters by folder, tag, and modification time", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            index.update(
+                "coax/current.md",
+                "---\ntags: [playback, recovery]\n---\n# Current\nprovider timeline",
+                300,
+            );
+            index.update(
+                "coax/old.md",
+                "---\ntags: [playback]\n---\n# Old\nprovider timeline",
+                100,
+            );
+            index.update(
+                "other/current.md",
+                "---\ntags: [recovery]\n---\nprovider timeline",
+                300,
+            );
+
+            const results = index.search({
+                query: "provider",
+                folder: "coax",
+                tag: "recovery",
+                modifiedAfter: 200,
+            });
+            assert.deepEqual(results.map((r) => r.path), ["coax/current.md"]);
+        } finally {
+            index.close();
+        }
+    });
+
+    it("uses exact aliases and groups multiple matching passages by note", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            index.update(
+                "coax/provider.md",
+                `---
+aliases:
+  - Edge recovery
+---
+# Stream behavior
+
+## Detection
+Provider recovery starts here with a resilience signal.
+
+## Retry
+Provider recovery continues here with a resilience signal.`,
+                100,
+            );
+            index.update("other.md", "An edge recovery phrase appears only in body text.", 100);
+
+            const aliasResults = index.search({ query: "Edge recovery" });
+            assert.equal(aliasResults[0].path, "coax/provider.md");
+            const passageResults = index.search({ query: "resilience signal" });
+            assert.deepEqual(passageResults.map((result) => result.path), ["coax/provider.md"]);
+            assert.match(passageResults[0].breadcrumb ?? "", /^Stream behavior > (Detection|Retry)$/);
+            assert.equal(index.chunkCount, 3);
+        } finally {
+            index.close();
+        }
+    });
+
+    it("keeps a broad title/path prefix from drowning body relevance", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            for (let day = 1; day <= 12; day++) {
+                index.update(
+                    `meetings/2026-01-${String(day).padStart(2, "0")}.md`,
+                    "# Daily log\n\nUnrelated notes about the weather.",
+                    day,
+                );
+            }
+            index.update(
+                "standup.md",
+                "# Team sync\n\nThe weekly meeting covers roadmap and meeting actions.",
+                100,
+            );
+
+            const results = index.search({ query: "meeting" });
+            assert.equal(results[0].path, "standup.md");
+            // Prefix-only path matches still surface, ranked below the body match.
+            assert.ok(results.some((result) => result.path.startsWith("meetings/")));
+        } finally {
+            index.close();
+        }
+    });
+
+    it("counts a note once no matter how many aliases match", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            index.update(
+                "many-aliases.md",
+                "---\naliases: [projx one, projx two, projx three, projx four]\n---\nBody.",
+                100,
+            );
+            index.update("exact.md", "---\naliases: [projx]\n---\nBody.", 100);
+
+            // One exact alias must outrank several prefix-only aliases; before
+            // deduplication the prefix rows summed into a higher fused score.
+            const results = index.search({ query: "projx" });
+            assert.deepEqual(
+                results.map((result) => result.path),
+                ["exact.md", "many-aliases.md"],
+            );
+        } finally {
+            index.close();
+        }
+    });
+
+    it("persists tags, links, backlinks, and checkpoints transactionally", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            index.beginBatch();
+            index.update("source.md", "---\ntags: [Project]\n---\nSee [[folder/Target]]", 10);
+            index.checkpoint = "rolled-back";
+            index.rollbackBatch();
+            assert.equal(index.size, 0);
+            assert.equal(index.checkpoint, "");
+
+            index.beginBatch();
+            index.update("source.md", "---\ntags: [Project]\n---\nSee [[folder/Target]]", 10);
+            index.checkpoint = "committed";
+            index.commitBatch();
+            assert.deepEqual(index.getTags("source.md"), ["Project"]);
+            assert.deepEqual(index.getLinks("source.md"), ["folder/Target"]);
+            assert.deepEqual(index.getBacklinks("folder/Target.md"), ["source.md"]);
+            assert.equal(index.checkpoint, "committed");
+        } finally {
+            index.close();
+        }
+    });
+
+    it("updates, removes, and clears notes without stale matches", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            index.update("note.md", "old terminology", 100);
+            index.update("note.md", "new terminology", 200);
+            assert.equal(index.search({ query: "old" }).length, 0);
+            assert.equal(index.search({ query: "new" }).length, 1);
+
+            index.remove("note.md");
+            assert.equal(index.search({ query: "new" }).length, 0);
+
+            index.update("one.md", "searchable", 100);
+            index.update("two.md", "searchable", 100);
+            index.clear();
+            assert.equal(index.size, 0);
+        } finally {
+            index.close();
+        }
+    });
+
+    it("commits and rolls back bulk update batches", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            index.beginBatch();
+            index.update("committed.md", "durable batch marker", 1);
+            index.commitBatch();
+            assert.deepEqual(
+                index.search({ query: "durable" }).map((result) => result.path),
+                ["committed.md"],
+            );
+
+            index.beginBatch();
+            index.update("rolled-back.md", "temporary batch marker", 2);
+            index.rollbackBatch();
+            assert.equal(index.search({ query: "temporary" }).length, 0);
+            assert.equal(index.size, 1);
+        } finally {
+            index.close();
+        }
+    });
+
+    it("persists the disk-backed corpus across process lifetimes", async () => {
+        const path = join(tmpDir, "persistent.sqlite");
+        const first = await FullTextIndex.open(path);
+        first.update("note.md", "durable provider recovery evidence", 123);
+        first.close();
+
+        const second = await FullTextIndex.open(path);
+        try {
+            assert.equal(second.createdFresh, false);
+            assert.equal(second.size, 1);
+            assert.deepEqual(
+                second.search({ query: "durable recovery" }).map((r) => r.path),
+                ["note.md"],
+            );
+        } finally {
+            second.close();
+        }
+    });
+
+    it("archives an index when its persisted backend identity does not match", async () => {
+        const path = join(tmpDir, "backend-identity.sqlite");
+        const first = await FullTextIndex.open(path, { backendIdentity: "backend-a" });
+        first.update("wrong-vault.md", "must not survive identity mismatch", 123);
+        first.checkpoint = "unsafe-checkpoint";
+        first.close();
+
+        const second = await FullTextIndex.open(path, { backendIdentity: "backend-b" });
+        try {
+            assert.equal(second.recreatedForIdentityMismatch, true);
+            assert.equal(second.size, 0);
+            assert.equal(second.checkpoint, "");
+        } finally {
+            second.close();
+        }
+        const names = await readdir(tmpDir);
+        assert.ok(names.some((name) =>
+            name.startsWith("backend-identity.sqlite.backend-mismatch-") && name.endsWith(".bak")));
+    });
+
+    it("persists a newer mtime even when note content is unchanged", async () => {
+        const index = await FullTextIndex.open(":memory:");
+        try {
+            index.update("same-content.md", "unchanged body", 100);
+            index.update("same-content.md", "unchanged body", 200);
+            assert.equal(index.getMtime("same-content.md"), 200);
+            assert.deepEqual(
+                index.search({ query: "unchanged" }).map((result) => result.path),
+                ["same-content.md"],
+            );
+        } finally {
+            index.close();
+        }
+    });
+
+    it("archives an incompatible schema before rebuilding", async () => {
+        const path = join(tmpDir, "old-schema.sqlite");
+        const old = await FullTextIndex.open(path);
+        old.close();
+        const Database = (await import("better-sqlite3-multiple-ciphers")).default;
+        const raw = new Database(path);
+        raw.pragma("user_version = 1");
+        raw.close();
+
+        const rebuilt = await FullTextIndex.open(path);
+        try {
+            assert.equal(rebuilt.recreatedForSchemaMismatch, true);
+            assert.equal(rebuilt.size, 0);
+        } finally {
+            rebuilt.close();
+        }
+        const names = await readdir(tmpDir);
+        assert.ok(names.some((name) => name.startsWith("old-schema.sqlite.schema-v1-") && name.endsWith(".bak")));
+    });
+
+    it("encrypts persisted note text and rejects the wrong key", async () => {
+        const path = join(tmpDir, "encrypted.sqlite");
+        const key = deriveFullTextIndexKey("correct horse battery staple", "encrypted-test");
+        const wrongKey = deriveFullTextIndexKey("wrong passphrase", "encrypted-test");
+        const secret = "highly sensitive recovery hypothesis";
+
+        const first = await FullTextIndex.open(path, { encryptionKey: key });
+        first.update("secret.md", secret, 123);
+        first.close();
+
+        const bytes = await readFile(path);
+        assert.notEqual(bytes.subarray(0, 16).toString("binary"), "SQLite format 3\0", "file header must be encrypted");
+        assert.equal(bytes.includes(Buffer.from(secret)), false, "note body must not appear in the file");
+        await assert.rejects(
+            () => FullTextIndex.open(path, { encryptionKey: wrongKey }),
+            /Unable to unlock the encrypted full-text index/,
+        );
+
+        const second = await FullTextIndex.open(path, { encryptionKey: key });
+        try {
+            assert.equal(second.encryptedAtRest, true);
+            assert.deepEqual(second.search({ query: "sensitive" }).map((r) => r.path), ["secret.md"]);
+        } finally {
+            second.close();
+        }
+    });
+
+    it("keeps encrypted database artifacts private and free of plaintext", async () => {
+        const path = join(tmpDir, "encrypted-artifacts.sqlite");
+        const key = deriveFullTextIndexKey("artifact passphrase", "artifact-test");
+        const firstSecret = "confidential durable decision marker";
+        const secondSecret = "confidential transactional journal marker";
+
+        const index = await FullTextIndex.open(path, { encryptionKey: key });
+        index.update("first.md", firstSecret, 1);
+        index.beginBatch();
+        index.update("second.md", secondSecret, 2);
+
+        const duringTransaction = (await readdir(tmpDir))
+            .filter((name) => name.startsWith("encrypted-artifacts.sqlite"));
+        assert.ok(
+            duringTransaction.includes("encrypted-artifacts.sqlite-journal"),
+            "the test must inspect an active rollback journal",
+        );
+        for (const name of duringTransaction) {
+            const artifactPath = join(tmpDir, name);
+            const bytes = await readFile(artifactPath);
+            assert.equal(bytes.includes(Buffer.from(firstSecret)), false, `${name} exposed committed note text`);
+            assert.equal(bytes.includes(Buffer.from(secondSecret)), false, `${name} exposed pending note text`);
+            assert.equal((await stat(artifactPath)).mode & 0o777, 0o600, `${name} must be owner-only`);
+        }
+
+        index.commitBatch();
+        index.close();
+        assert.equal(
+            (await readdir(tmpDir)).includes("encrypted-artifacts.sqlite-journal"),
+            false,
+            "the rollback journal must be removed after commit and close",
+        );
+
+        const Database = (await import("better-sqlite3-multiple-ciphers")).default;
+        const raw = new Database(path);
+        raw.pragma("cipher = sqlcipher");
+        raw.key(key);
+        raw.pragma("user_version = 1");
+        raw.close();
+
+        const rebuilt = await FullTextIndex.open(path, { encryptionKey: key });
+        rebuilt.close();
+        const afterRebuild = (await readdir(tmpDir))
+            .filter((name) => name.startsWith("encrypted-artifacts.sqlite"));
+        assert.ok(afterRebuild.some((name) => name.endsWith(".bak")), "encrypted schema backup missing");
+        for (const name of afterRebuild) {
+            const artifactPath = join(tmpDir, name);
+            const bytes = await readFile(artifactPath);
+            assert.notEqual(bytes.subarray(0, 16).toString("binary"), "SQLite format 3\0", `${name} is plaintext SQLite`);
+            assert.equal(bytes.includes(Buffer.from(firstSecret)), false, `${name} exposed note text`);
+            assert.equal(bytes.includes(Buffer.from(secondSecret)), false, `${name} exposed note text`);
+            assert.equal((await stat(artifactPath)).mode & 0o777, 0o600, `${name} must be owner-only`);
+        }
+    });
+
+    it("migrates an existing plaintext index to encrypted storage", async () => {
+        const path = join(tmpDir, "plaintext-migration.sqlite");
+        const key = deriveFullTextIndexKey("migration passphrase", "migration-test");
+        const first = await FullTextIndex.open(path);
+        first.update("legacy.md", "legacy plaintext marker", 321);
+        first.close();
+        assert.equal(
+            (await readFile(path)).subarray(0, 16).toString("binary"),
+            "SQLite format 3\0",
+        );
+
+        const migrated = await FullTextIndex.open(path, { encryptionKey: key });
+        try {
+            assert.equal(migrated.migratedFromPlaintext, true);
+            assert.deepEqual(migrated.search({ query: "legacy" }).map((r) => r.path), ["legacy.md"]);
+        } finally {
+            migrated.close();
+        }
+        assert.notEqual(
+            (await readFile(path)).subarray(0, 16).toString("binary"),
+            "SQLite format 3\0",
+        );
+        for (const name of (await readdir(tmpDir)).filter((name) =>
+            name.startsWith("plaintext-migration.sqlite"))) {
+            const artifactPath = join(tmpDir, name);
+            const bytes = await readFile(artifactPath);
+            assert.equal(bytes.includes(Buffer.from("legacy plaintext marker")), false, `${name} retained plaintext`);
+            assert.equal((await stat(artifactPath)).mode & 0o777, 0o600, `${name} must be owner-only`);
+        }
+    });
+
+    it("re-keys an HKDF-only encrypted index with the password-hardened key", async () => {
+        const path = join(tmpDir, "legacy-key-migration.sqlite");
+        const passphrase = "legacy migration passphrase";
+        const vaultId = "legacy-migration-test";
+        const legacyKey = deriveLegacyFullTextIndexKey(passphrase, vaultId);
+        const hardenedKey = deriveFullTextIndexKey(passphrase, vaultId);
+
+        const legacy = await FullTextIndex.open(path, { encryptionKey: legacyKey });
+        legacy.update("legacy.md", "legacy encrypted provider marker", 456);
+        legacy.close();
+
+        await assert.rejects(
+            () => FullTextIndex.open(path, { encryptionKey: hardenedKey }),
+            /Unable to unlock the encrypted full-text index/,
+        );
+
+        const migrated = await FullTextIndex.open(path, {
+            encryptionKey: hardenedKey,
+            legacyEncryptionKey: legacyKey,
+        });
+        try {
+            assert.equal(migrated.migratedFromLegacyEncryption, true);
+            assert.deepEqual(
+                migrated.search({ query: "provider" }).map((result) => result.path),
+                ["legacy.md"],
+            );
+        } finally {
+            migrated.close();
+        }
+
+        const reopened = await FullTextIndex.open(path, {
+            encryptionKey: hardenedKey,
+            legacyEncryptionKey: legacyKey,
+        });
+        try {
+            assert.equal(reopened.migratedFromLegacyEncryption, false);
+            assert.deepEqual(
+                reopened.search({ query: "encrypted" }).map((result) => result.path),
+                ["legacy.md"],
+            );
+        } finally {
+            reopened.close();
+        }
+
+        await assert.rejects(
+            () => FullTextIndex.open(path, { encryptionKey: legacyKey }),
+            /Unable to unlock the encrypted full-text index/,
+        );
+    });
+});

--- a/src/full-text-search.ts
+++ b/src/full-text-search.ts
@@ -1,0 +1,661 @@
+/** Encrypted, disk-backed, PKB-aware search for vault notes. */
+
+import { chmod, mkdir, open as openFile, rename } from "fs/promises";
+import { basename, dirname, join } from "path";
+import { createHash, hkdfSync, scryptSync } from "node:crypto";
+import Database from "better-sqlite3-multiple-ciphers";
+import { chunkMarkdown } from "./markdown-chunker.js";
+import { parseFrontmatterAndLinks } from "./parse.js";
+
+export type FullTextSearchMode = "all" | "any" | "phrase";
+export interface FullTextSearchOptions {
+    query: string;
+    folder?: string;
+    tag?: string;
+    modifiedAfter?: number;
+    mode?: FullTextSearchMode;
+    limit?: number;
+}
+export interface FullTextSearchResult {
+    path: string;
+    mtime: number;
+    rank: number;
+    snippet: string;
+    heading?: string;
+    breadcrumb?: string;
+    matchedBy?: "exact" | "metadata" | "passage";
+}
+export interface FullTextSearchSetting { enabled: boolean; encryptIndex: boolean }
+export interface FullTextIndexOptions {
+    encryptionKey?: Buffer;
+    /** HKDF-only key used by the first encrypted-index prototype. Migration only. */
+    legacyEncryptionKey?: Buffer;
+    /** Opaque hash of the backing filesystem root or CouchDB database. */
+    backendIdentity?: string;
+}
+
+export type SearchBackendIdentity =
+    | { kind: "filesystem"; location: string }
+    | { kind: "couchdb"; url: string; database: string };
+
+/**
+ * Derive an opaque, stable identity from the backend that owns the notes.
+ * VAULT_NAME is intentionally absent: it is presentation metadata and is not
+ * sufficient to isolate persisted results or CouchDB checkpoints.
+ */
+export function deriveSearchBackendId(backend: SearchBackendIdentity): string {
+    let canonical: string;
+    if (backend.kind === "filesystem") {
+        canonical = `filesystem\0${backend.location.replace(/\\/g, "/").replace(/\/+$/, "") || "/"}`;
+    } else {
+        const url = new URL(backend.url);
+        url.username = "";
+        url.password = "";
+        url.search = "";
+        url.hash = "";
+        url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+        canonical = `couchdb\0${url.toString()}\0${backend.database}`;
+    }
+    return createHash("sha256").update(canonical).digest("hex").slice(0, 24);
+}
+
+export function searchIndexStoragePaths(baseDataDir: string, backendId: string, vaultName: string) {
+    const legacyVaultId = createHash("sha256").update(vaultName).digest("hex").slice(0, 12);
+    return {
+        dataDir: join(baseDataDir, "backends", backendId),
+        indexPath: join(baseDataDir, "backends", backendId, "full-text-index-v2.sqlite"),
+        // Detection only. This path is never reused because it has no verifiable backend identity.
+        legacyIndexPath: join(baseDataDir, legacyVaultId, "full-text-index-v2.sqlite"),
+    };
+}
+
+const SCHEMA_VERSION = 2;
+const CANDIDATE_LIMIT = 200;
+const EXACT_WEIGHT = 12;
+// Prefix matches exist for partial-word queries the FTS lanes cannot serve at
+// all; when a full word matches a title, the metadata lane already ranks it.
+// Keeping this below PASSAGE_WEIGHT stops a broad title/path prefix (e.g.
+// "meeting" against a Meetings/ folder) from drowning genuine body relevance.
+const EXACT_PREFIX_WEIGHT = 2;
+const METADATA_WEIGHT = 5;
+const PASSAGE_WEIGHT = 3;
+const INDEX_KDF_SCRYPT_OPTIONS = {
+    N: 1 << 15, r: 8, p: 1, maxmem: 64 * 1024 * 1024,
+} as const;
+
+function queryTokens(value: string): string[] {
+    return value.normalize("NFKC").match(/[\p{L}\p{N}_]+/gu) ?? [];
+}
+function quotePhrase(tokens: string[]): string {
+    return `"${tokens.join(" ").replaceAll('"', '""')}"`;
+}
+export function buildFtsQuery(query: string, mode: FullTextSearchMode = "all"): string {
+    const tokens = queryTokens(query);
+    if (tokens.length === 0) throw new Error("Search query must contain at least one letter or number.");
+    return mode === "phrase"
+        ? quotePhrase(tokens)
+        : tokens.map((token) => quotePhrase([token])).join(mode === "any" ? " OR " : " AND ");
+}
+export function resolveFullTextSearchSetting(
+    raw: string | undefined,
+    encryptedRemoteVault: boolean,
+): FullTextSearchSetting {
+    const value = raw?.trim().toLowerCase() || "auto";
+    if (!["auto", "true", "false"].includes(value)) {
+        throw new Error("FULL_TEXT_SEARCH must be 'auto', 'true', or 'false'.");
+    }
+    const enabled = value !== "false";
+    return { enabled, encryptIndex: enabled && encryptedRemoteVault };
+}
+export function deriveLegacyFullTextIndexKey(passphrase: string, vaultId: string): Buffer {
+    return Buffer.from(hkdfSync(
+        "sha256", Buffer.from(passphrase, "utf8"), Buffer.from(vaultId, "utf8"),
+        Buffer.from("obsidian-sync-mcp/full-text-index/v1", "utf8"), 32,
+    ));
+}
+export function deriveFullTextIndexKey(passphrase: string, vaultId: string): Buffer {
+    const vaultKey = scryptSync(
+        Buffer.from(passphrase, "utf8"),
+        Buffer.from(`obsidian-sync-mcp/vault-kdf/v1/${vaultId}`, "utf8"),
+        32,
+        INDEX_KDF_SCRYPT_OPTIONS,
+    );
+    try {
+        return Buffer.from(hkdfSync(
+            "sha256", vaultKey, Buffer.from(vaultId, "utf8"),
+            Buffer.from("obsidian-sync-mcp/full-text-index/v2", "utf8"), 32,
+        ));
+    } finally {
+        vaultKey.fill(0);
+    }
+}
+
+async function hasPlaintextSqliteHeader(path: string): Promise<boolean> {
+    try {
+        const file = await openFile(path, "r");
+        try {
+            const header = Buffer.alloc(16);
+            const { bytesRead } = await file.read(header, 0, header.length, 0);
+            return bytesRead === header.length && header.equals(Buffer.from("SQLite format 3\0", "binary"));
+        } finally { await file.close(); }
+    } catch { return false; }
+}
+function normalizeLookup(value: string): string {
+    return value.normalize("NFKC").toLocaleLowerCase("en-US")
+        .replace(/\.md$/i, "").replace(/[_-]+/g, " ")
+        .replace(/[^\p{L}\p{N}]+/gu, " ").trim().replace(/\s+/g, " ");
+}
+function pathAsText(path: string): string {
+    return path.replace(/\.md$/i, "").replace(/[\\/_-]+/g, " ");
+}
+function escapeLike(value: string): string { return value.replace(/[\\%_]/g, "\\$&"); }
+function normalizeSnippet(value: string): string { return value.replace(/\s+/g, " ").trim(); }
+function extractSearchFields(path: string, content: string) {
+    const metadata = parseFrontmatterAndLinks(content);
+    const firstHeading = content.match(/^#\s+(.+?)\s*#*\s*$/m)?.[1]?.trim();
+    const title = firstHeading || basename(path, ".md");
+    return {
+        title,
+        titleNorm: normalizeLookup(title),
+        basenameNorm: normalizeLookup(basename(path, ".md")),
+        pathNorm: normalizeLookup(path),
+        pathText: pathAsText(path),
+        aliases: metadata.aliases,
+        tags: metadata.tags,
+        links: metadata.links,
+        linkLabels: metadata.linkLabels,
+        chunks: chunkMarkdown(content),
+        contentHash: createHash("sha256").update(content).digest("hex"),
+    };
+}
+interface Candidate {
+    path: string;
+    mtime: number;
+    score: number;
+    snippet: string;
+    heading?: string;
+    breadcrumb?: string;
+    matchedBy: "exact" | "metadata" | "passage";
+    snippetPriority: number;
+}
+
+export class FullTextIndex {
+    private db: Database.Database;
+    private statements = new Map<string, Database.Statement>();
+    private batchOpen = false;
+    readonly createdFresh: boolean;
+    readonly encryptedAtRest: boolean;
+    readonly migratedFromPlaintext: boolean;
+    readonly migratedFromLegacyEncryption: boolean;
+    recreatedForSchemaMismatch = false;
+    recreatedForIdentityMismatch = false;
+
+    private constructor(
+        db: Database.Database,
+        createdFresh: boolean,
+        encryptedAtRest: boolean,
+        migratedFromPlaintext: boolean,
+        migratedFromLegacyEncryption: boolean,
+    ) {
+        this.db = db;
+        this.createdFresh = createdFresh;
+        this.encryptedAtRest = encryptedAtRest;
+        this.migratedFromPlaintext = migratedFromPlaintext;
+        this.migratedFromLegacyEncryption = migratedFromLegacyEncryption;
+    }
+
+    /** Reuse native statements; rebuilding them per note causes large native-memory spikes. */
+    private statement(sql: string): Database.Statement {
+        let statement = this.statements.get(sql);
+        if (!statement) {
+            statement = this.db.prepare(sql);
+            this.statements.set(sql, statement);
+        }
+        return statement;
+    }
+
+    static async open(path: string, options: FullTextIndexOptions = {}): Promise<FullTextIndex> {
+        if (path !== ":memory:") await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+        const migratedFromPlaintext = Boolean(
+            options.encryptionKey && path !== ":memory:" && await hasPlaintextSqliteHeader(path),
+        );
+        let migratedFromLegacyEncryption = false;
+        let db: Database.Database;
+        if (options.encryptionKey) {
+            if (migratedFromPlaintext) {
+                db = new Database(path);
+                db.pragma("cipher = sqlcipher");
+                try {
+                    db.rekey(options.encryptionKey);
+                    db.prepare("SELECT count(*) AS count FROM sqlite_master").get();
+                } catch (error) {
+                    db.close();
+                    throw new Error("Unable to encrypt the existing plaintext full-text index.", { cause: error });
+                }
+            } else {
+                const openEncrypted = (key: Buffer): Database.Database => {
+                    const encryptedDb = new Database(path);
+                    encryptedDb.pragma("cipher = sqlcipher");
+                    try {
+                        encryptedDb.key(key);
+                        encryptedDb.prepare("SELECT count(*) AS count FROM sqlite_master").get();
+                        return encryptedDb;
+                    } catch (error) { encryptedDb.close(); throw error; }
+                };
+                try {
+                    db = openEncrypted(options.encryptionKey);
+                } catch (primaryError) {
+                    if (!options.legacyEncryptionKey) {
+                        throw new Error(
+                            "Unable to unlock the encrypted full-text index. " +
+                            "Check the vault passphrase or delete the index to rebuild it.",
+                            { cause: primaryError },
+                        );
+                    }
+                    try {
+                        const legacyDb = openEncrypted(options.legacyEncryptionKey);
+                        try { legacyDb.rekey(options.encryptionKey); } finally { legacyDb.close(); }
+                        db = openEncrypted(options.encryptionKey);
+                        migratedFromLegacyEncryption = true;
+                    } catch (legacyError) {
+                        throw new Error(
+                            "Unable to unlock the encrypted full-text index. " +
+                            "Check the vault passphrase or delete the index to rebuild it.",
+                            { cause: legacyError },
+                        );
+                    }
+                }
+            }
+        } else {
+            db = new Database(path);
+        }
+
+        db.exec(`
+            PRAGMA journal_mode = DELETE;
+            PRAGMA synchronous = NORMAL;
+            PRAGMA foreign_keys = ON;
+            PRAGMA cache_size = -32768;
+            PRAGMA mmap_size = 134217728;
+            PRAGMA temp_store = MEMORY;
+            PRAGMA memory_security = 1;
+        `);
+        const versionRow = db.prepare("PRAGMA user_version").get() as { user_version?: number } | undefined;
+        const version = Number(versionRow?.user_version ?? 0);
+        if (version !== 0 && version !== SCHEMA_VERSION) {
+            db.close();
+            if (path === ":memory:") throw new Error(`Unsupported in-memory search schema ${version}.`);
+            const backupPath = `${path}.schema-v${version}-${Date.now()}.bak`;
+            await rename(path, backupPath);
+            const rebuilt = await FullTextIndex.open(path, options);
+            rebuilt.recreatedForSchemaMismatch = true;
+            return rebuilt;
+        }
+        const createdFresh = version === 0;
+        if (createdFresh) {
+            db.exec(`
+                CREATE TABLE notes(
+                    path TEXT PRIMARY KEY, mtime REAL NOT NULL, content_hash TEXT NOT NULL,
+                    title TEXT NOT NULL, title_norm TEXT NOT NULL, basename_norm TEXT NOT NULL,
+                    path_norm TEXT NOT NULL,
+                    path_text TEXT NOT NULL, aliases TEXT NOT NULL, tags TEXT NOT NULL,
+                    link_labels TEXT NOT NULL
+                );
+                CREATE INDEX notes_title_norm_idx ON notes(title_norm);
+                CREATE INDEX notes_basename_norm_idx ON notes(basename_norm);
+                CREATE INDEX notes_path_norm_idx ON notes(path_norm);
+                CREATE TABLE note_aliases(
+                    path TEXT NOT NULL REFERENCES notes(path) ON DELETE CASCADE,
+                    alias TEXT NOT NULL, alias_norm TEXT NOT NULL,
+                    PRIMARY KEY(path, alias_norm)
+                );
+                CREATE INDEX note_aliases_norm_idx ON note_aliases(alias_norm);
+                CREATE TABLE note_tags(
+                    path TEXT NOT NULL REFERENCES notes(path) ON DELETE CASCADE,
+                    tag TEXT NOT NULL, tag_norm TEXT NOT NULL,
+                    PRIMARY KEY(path, tag_norm)
+                );
+                CREATE INDEX note_tags_norm_idx ON note_tags(tag_norm);
+                CREATE TABLE note_links(
+                    path TEXT NOT NULL REFERENCES notes(path) ON DELETE CASCADE,
+                    target TEXT NOT NULL, target_norm TEXT NOT NULL, target_name_norm TEXT NOT NULL,
+                    PRIMARY KEY(path, target_norm)
+                );
+                CREATE INDEX note_links_target_idx ON note_links(target_norm);
+                CREATE INDEX note_links_name_idx ON note_links(target_name_norm);
+                CREATE TABLE chunks(
+                    id INTEGER PRIMARY KEY,
+                    path TEXT NOT NULL REFERENCES notes(path) ON DELETE CASCADE,
+                    ordinal INTEGER NOT NULL, heading TEXT NOT NULL,
+                    breadcrumb TEXT NOT NULL, body TEXT NOT NULL,
+                    UNIQUE(path, ordinal)
+                );
+                CREATE INDEX chunks_path_idx ON chunks(path);
+                CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                CREATE VIRTUAL TABLE notes_fts USING fts5(
+                    title, aliases, tags, path_text, link_labels,
+                    content = 'notes', content_rowid = 'rowid',
+                    tokenize = 'unicode61 remove_diacritics 2'
+                );
+                CREATE VIRTUAL TABLE chunks_fts USING fts5(
+                    heading, breadcrumb, body,
+                    content = 'chunks', content_rowid = 'id',
+                    tokenize = 'porter unicode61 remove_diacritics 2'
+                );
+                CREATE TRIGGER notes_ai AFTER INSERT ON notes BEGIN
+                    INSERT INTO notes_fts(rowid, title, aliases, tags, path_text, link_labels)
+                    VALUES (new.rowid, new.title, new.aliases, new.tags, new.path_text, new.link_labels);
+                END;
+                CREATE TRIGGER notes_ad AFTER DELETE ON notes BEGIN
+                    INSERT INTO notes_fts(notes_fts, rowid, title, aliases, tags, path_text, link_labels)
+                    VALUES ('delete', old.rowid, old.title, old.aliases, old.tags, old.path_text, old.link_labels);
+                END;
+                CREATE TRIGGER notes_au AFTER UPDATE ON notes BEGIN
+                    INSERT INTO notes_fts(notes_fts, rowid, title, aliases, tags, path_text, link_labels)
+                    VALUES ('delete', old.rowid, old.title, old.aliases, old.tags, old.path_text, old.link_labels);
+                    INSERT INTO notes_fts(rowid, title, aliases, tags, path_text, link_labels)
+                    VALUES (new.rowid, new.title, new.aliases, new.tags, new.path_text, new.link_labels);
+                END;
+                CREATE TRIGGER chunks_ai AFTER INSERT ON chunks BEGIN
+                    INSERT INTO chunks_fts(rowid, heading, breadcrumb, body)
+                    VALUES (new.id, new.heading, new.breadcrumb, new.body);
+                END;
+                CREATE TRIGGER chunks_ad AFTER DELETE ON chunks BEGIN
+                    INSERT INTO chunks_fts(chunks_fts, rowid, heading, breadcrumb, body)
+                    VALUES ('delete', old.id, old.heading, old.breadcrumb, old.body);
+                END;
+                CREATE TRIGGER chunks_au AFTER UPDATE ON chunks BEGIN
+                    INSERT INTO chunks_fts(chunks_fts, rowid, heading, breadcrumb, body)
+                    VALUES ('delete', old.id, old.heading, old.breadcrumb, old.body);
+                    INSERT INTO chunks_fts(rowid, heading, breadcrumb, body)
+                    VALUES (new.id, new.heading, new.breadcrumb, new.body);
+                END;
+                PRAGMA user_version = ${SCHEMA_VERSION};
+            `);
+        }
+        if (options.backendIdentity) {
+            const identityRow = db.prepare(
+                "SELECT value FROM index_meta WHERE key = 'backend_identity'",
+            ).get() as { value?: string } | undefined;
+            if (!createdFresh && identityRow?.value !== options.backendIdentity) {
+                db.close();
+                if (path === ":memory:") {
+                    throw new Error("In-memory search index backend identity mismatch.");
+                }
+                const backupPath = `${path}.backend-mismatch-${Date.now()}.bak`;
+                await rename(path, backupPath);
+                const rebuilt = await FullTextIndex.open(path, options);
+                rebuilt.recreatedForIdentityMismatch = true;
+                return rebuilt;
+            }
+            if (createdFresh) {
+                db.prepare(
+                    "INSERT INTO index_meta(key, value) VALUES ('backend_identity', ?)",
+                ).run(options.backendIdentity);
+            }
+        }
+        if (path !== ":memory:") await chmod(path, 0o600);
+        return new FullTextIndex(
+            db, createdFresh, Boolean(options.encryptionKey),
+            migratedFromPlaintext, migratedFromLegacyEncryption,
+        );
+    }
+
+    update(path: string, content: string, mtime?: number): void {
+        const fields = extractSearchFields(path, content);
+        const current = this.statement("SELECT mtime, content_hash FROM notes WHERE path = ?").get(path) as
+            | { mtime?: number | string; content_hash?: string }
+            | undefined;
+        if (current && current.content_hash === fields.contentHash &&
+            (mtime === undefined || Number(current.mtime) === mtime)) return;
+        const ownsTransaction = !this.batchOpen;
+        if (ownsTransaction) this.db.exec("BEGIN IMMEDIATE");
+        try {
+            this.statement("DELETE FROM notes WHERE path = ?").run(path);
+            this.statement(`
+                INSERT INTO notes(
+                    path, mtime, content_hash, title, title_norm, basename_norm,
+                    path_norm, path_text, aliases, tags, link_labels
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `).run(
+                path, mtime ?? 0, fields.contentHash, fields.title, fields.titleNorm,
+                fields.basenameNorm, fields.pathNorm, fields.pathText, fields.aliases.join("\n"),
+                fields.tags.join(" "), fields.linkLabels.join("\n"),
+            );
+            const insertAlias = this.statement(
+                "INSERT OR IGNORE INTO note_aliases(path, alias, alias_norm) VALUES (?, ?, ?)",
+            );
+            for (const alias of fields.aliases) insertAlias.run(path, alias, normalizeLookup(alias));
+            const insertTag = this.statement(
+                "INSERT OR IGNORE INTO note_tags(path, tag, tag_norm) VALUES (?, ?, ?)",
+            );
+            for (const tag of fields.tags) insertTag.run(path, tag, tag.toLocaleLowerCase("en-US"));
+            const insertLink = this.statement(
+                "INSERT OR IGNORE INTO note_links(path, target, target_norm, target_name_norm) VALUES (?, ?, ?, ?)",
+            );
+            for (const target of fields.links) {
+                const withoutExtension = target.replace(/\.md$/i, "");
+                const name = withoutExtension.split("/").pop() ?? withoutExtension;
+                insertLink.run(path, target, normalizeLookup(withoutExtension), normalizeLookup(name));
+            }
+            const insertChunk = this.statement(
+                "INSERT INTO chunks(path, ordinal, heading, breadcrumb, body) VALUES (?, ?, ?, ?, ?)",
+            );
+            for (const chunk of fields.chunks) {
+                insertChunk.run(path, chunk.ordinal, chunk.heading, chunk.breadcrumb, chunk.body);
+            }
+            if (ownsTransaction) this.db.exec("COMMIT");
+        } catch (error) {
+            if (ownsTransaction) this.db.exec("ROLLBACK");
+            throw error;
+        }
+    }
+
+    beginBatch(): void {
+        if (this.batchOpen) return;
+        this.db.exec("BEGIN IMMEDIATE");
+        this.batchOpen = true;
+    }
+    commitBatch(): void {
+        if (!this.batchOpen) return;
+        this.db.exec("COMMIT");
+        this.batchOpen = false;
+    }
+    rollbackBatch(): void {
+        if (!this.batchOpen) return;
+        this.db.exec("ROLLBACK");
+        this.batchOpen = false;
+    }
+    remove(path: string): void { this.statement("DELETE FROM notes WHERE path = ?").run(path); }
+    clear(): void { this.db.exec("DELETE FROM notes; DELETE FROM index_meta;"); }
+
+    private filterSql(options: FullTextSearchOptions, alias = "notes") {
+        const conditions: string[] = [];
+        const parameters: Array<string | number> = [];
+        if (options.folder) {
+            const folder = options.folder.replace(/[\\/]+$/, "");
+            conditions.push(`${alias}.path LIKE ? ESCAPE '\\'`);
+            parameters.push(`${escapeLike(folder)}/%`);
+        }
+        if (options.tag) {
+            conditions.push(`EXISTS (
+                SELECT 1 FROM note_tags filter_tags
+                WHERE filter_tags.path = ${alias}.path AND filter_tags.tag_norm = ?
+            )`);
+            parameters.push(options.tag.toLocaleLowerCase("en-US"));
+        }
+        if (options.modifiedAfter !== undefined) {
+            conditions.push(`${alias}.mtime >= ?`);
+            parameters.push(options.modifiedAfter);
+        }
+        return { conditions, parameters };
+    }
+
+    search(options: FullTextSearchOptions): FullTextSearchResult[] {
+        const limit = Math.max(1, Math.min(options.limit ?? 10, 50));
+        const match = buildFtsQuery(options.query, options.mode);
+        const normalized = normalizeLookup(options.query);
+        const candidates = new Map<string, Candidate>();
+        const add = (
+            row: { path: string; mtime: number | string; snippet?: string; heading?: string; breadcrumb?: string },
+            laneRank: number,
+            laneWeight: number,
+            matchedBy: Candidate["matchedBy"],
+            snippetPriority: number,
+        ) => {
+            const contribution = laneWeight / (60 + laneRank);
+            const existing = candidates.get(row.path);
+            if (!existing) {
+                candidates.set(row.path, {
+                    path: row.path, mtime: Number(row.mtime), score: contribution,
+                    snippet: normalizeSnippet(row.snippet ?? ""),
+                    heading: row.heading || undefined, breadcrumb: row.breadcrumb || undefined,
+                    matchedBy, snippetPriority,
+                });
+                return;
+            }
+            existing.score += contribution;
+            if (snippetPriority > existing.snippetPriority && row.snippet) {
+                existing.snippet = normalizeSnippet(row.snippet);
+                existing.heading = row.heading || undefined;
+                existing.breadcrumb = row.breadcrumb || undefined;
+                existing.matchedBy = matchedBy;
+                existing.snippetPriority = snippetPriority;
+            }
+        };
+
+        const exactFilters = this.filterSql(options);
+        const prefix = `${escapeLike(normalized)}%`;
+        // A note matched by several aliases must contribute once, at its best rank.
+        const exactRows = this.statement(`
+            SELECT notes.path, notes.mtime, notes.title AS snippet,
+                MIN(CASE WHEN notes.title_norm = ? OR notes.basename_norm = ? OR notes.path_norm = ? THEN 0
+                     WHEN note_aliases.alias_norm = ? THEN 1 ELSE 2 END) AS lane_rank
+            FROM notes LEFT JOIN note_aliases ON note_aliases.path = notes.path
+            WHERE (notes.title_norm = ? OR notes.basename_norm = ? OR notes.path_norm = ? OR
+                   note_aliases.alias_norm = ? OR notes.title_norm LIKE ? ESCAPE '\\' OR
+                   notes.basename_norm LIKE ? ESCAPE '\\' OR notes.path_norm LIKE ? ESCAPE '\\' OR
+                   note_aliases.alias_norm LIKE ? ESCAPE '\\')
+                ${exactFilters.conditions.length ? `AND ${exactFilters.conditions.join(" AND ")}` : ""}
+            GROUP BY notes.path
+            ORDER BY lane_rank, notes.path LIMIT ?
+        `).all(
+            normalized, normalized, normalized, normalized,
+            normalized, normalized, normalized, normalized, prefix, prefix, prefix, prefix,
+            ...exactFilters.parameters, CANDIDATE_LIMIT,
+        ) as Array<{ path: string; mtime: number; snippet: string; lane_rank: number }>;
+        exactRows.forEach((row, index) =>
+            add(row, index, Number(row.lane_rank) === 2 ? EXACT_PREFIX_WEIGHT : EXACT_WEIGHT, "exact", 1));
+
+        const metadataFilters = this.filterSql(options);
+        const metadataRows = this.statement(`
+            SELECT notes.path, notes.mtime,
+                CASE WHEN highlight(notes_fts, 0, '**', '**') LIKE '%**%'
+                        THEN highlight(notes_fts, 0, '**', '**')
+                     WHEN highlight(notes_fts, 1, '**', '**') LIKE '%**%'
+                        THEN highlight(notes_fts, 1, '**', '**')
+                     ELSE snippet(notes_fts, 4, '**', '**', ' … ', 18) END AS snippet,
+                notes_fts.rank AS lane_score
+            FROM notes_fts JOIN notes ON notes.rowid = notes_fts.rowid
+            WHERE notes_fts MATCH ? AND notes_fts.rank MATCH ?
+                ${metadataFilters.conditions.length ? `AND ${metadataFilters.conditions.join(" AND ")}` : ""}
+            ORDER BY lane_score, notes.path LIMIT ?
+        `).all(
+            match, "bm25(12.0, 10.0, 5.0, 3.0, 7.0)",
+            ...metadataFilters.parameters, CANDIDATE_LIMIT,
+        ) as Array<{ path: string; mtime: number; snippet: string; lane_score: number }>;
+        metadataRows.forEach((row, index) => add(row, index, METADATA_WEIGHT, "metadata", 3));
+
+        const passageFilters = this.filterSql(options);
+        const passageRows = this.statement(`
+            WITH hits AS (
+                SELECT notes.path, notes.mtime, chunks.ordinal, chunks.heading, chunks.breadcrumb,
+                    CASE WHEN highlight(chunks_fts, 0, '**', '**') LIKE '%**%'
+                            THEN highlight(chunks_fts, 0, '**', '**')
+                         ELSE snippet(chunks_fts, 2, '**', '**', ' … ', 28) END AS snippet,
+                    chunks_fts.rank AS lane_score
+                FROM chunks_fts
+                JOIN chunks ON chunks.id = chunks_fts.rowid
+                JOIN notes ON notes.path = chunks.path
+                WHERE chunks_fts MATCH ? AND chunks_fts.rank MATCH ?
+                    ${passageFilters.conditions.length ? `AND ${passageFilters.conditions.join(" AND ")}` : ""}
+                ORDER BY lane_score, notes.path, chunks.ordinal
+                LIMIT ?
+            ), grouped AS (
+                SELECT *, ROW_NUMBER() OVER (PARTITION BY path ORDER BY lane_score, ordinal) AS note_rank
+                FROM hits
+            )
+            SELECT path, mtime, heading, breadcrumb, snippet, lane_score
+            FROM grouped WHERE note_rank = 1
+            ORDER BY lane_score, path LIMIT ?
+        `).all(
+            match, "bm25(9.0, 5.0, 1.0)",
+            ...passageFilters.parameters, CANDIDATE_LIMIT * 5, CANDIDATE_LIMIT,
+        ) as Array<{
+            path: string; mtime: number; heading: string; breadcrumb: string;
+            snippet: string; lane_score: number;
+        }>;
+        passageRows.forEach((row, index) => add(row, index, PASSAGE_WEIGHT, "passage", 2));
+
+        return [...candidates.values()]
+            .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path))
+            .slice(0, limit)
+            .map(({ score, snippetPriority: _priority, ...result }) => ({ ...result, rank: score }));
+    }
+
+    listWithMtime(folder?: string): Array<{ path: string; mtime: number }> {
+        const parameters: string[] = [];
+        const where = folder ? "WHERE path LIKE ? ESCAPE '\\'" : "";
+        if (folder) parameters.push(`${escapeLike(folder.replace(/[\\/]+$/, ""))}/%`);
+        return this.statement(`SELECT path, mtime FROM notes ${where} ORDER BY path`).all(...parameters)
+            .map((row: any) => ({ path: String(row.path), mtime: Number(row.mtime) }));
+    }
+    getMtime(path: string): number {
+        const row = this.statement("SELECT mtime FROM notes WHERE path = ?").get(path) as
+            | { mtime?: number | string }
+            | undefined;
+        return Number(row?.mtime ?? 0);
+    }
+    getTags(path: string): string[] {
+        return this.statement("SELECT tag FROM note_tags WHERE path = ? ORDER BY rowid").all(path)
+            .map((row: any) => String(row.tag));
+    }
+    getLinks(path: string): string[] {
+        return this.statement("SELECT target FROM note_links WHERE path = ? ORDER BY rowid").all(path)
+            .map((row: any) => String(row.target));
+    }
+    getBacklinks(path: string): string[] {
+        const normalized = normalizeLookup(path);
+        const name = normalizeLookup(path.replace(/\.md$/i, "").split("/").pop() ?? path);
+        return this.statement(`
+            SELECT DISTINCT path FROM note_links
+            WHERE target_norm = ? OR target_name_norm = ? ORDER BY path
+        `).all(normalized, name).map((row: any) => String(row.path));
+    }
+    listAllTags(): Array<{ tag: string; count: number }> {
+        return this.statement(`
+            SELECT min(tag) AS tag, count(*) AS count FROM note_tags
+            GROUP BY tag_norm ORDER BY count DESC, tag
+        `).all().map((row: any) => ({ tag: String(row.tag), count: Number(row.count) }));
+    }
+    get checkpoint(): string {
+        const row = this.statement("SELECT value FROM index_meta WHERE key = 'since'").get() as
+            | { value?: string }
+            | undefined;
+        return row?.value ?? "";
+    }
+    set checkpoint(value: string) {
+        this.statement(`
+            INSERT INTO index_meta(key, value) VALUES ('since', ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        `).run(value);
+    }
+    get size(): number {
+        const row = this.statement("SELECT count(*) AS count FROM notes").get() as { count?: number } | undefined;
+        return Number(row?.count ?? 0);
+    }
+    get chunkCount(): number {
+        const row = this.statement("SELECT count(*) AS count FROM chunks").get() as { count?: number } | undefined;
+        return Number(row?.count ?? 0);
+    }
+    close(): void { this.rollbackBatch(); this.statements.clear(); this.db.close(); }
+}

--- a/src/full-text-search.ts
+++ b/src/full-text-search.ts
@@ -466,7 +466,13 @@ export class FullTextIndex {
         this.batchOpen = false;
     }
     remove(path: string): void { this.statement("DELETE FROM notes WHERE path = ?").run(path); }
-    clear(): void { this.db.exec("DELETE FROM notes; DELETE FROM index_meta;"); }
+    // Preserve backend_identity across a clear: clear() only ever rebuilds the
+    // *same* backend (the CouchDB catch-up fallback), and identity is re-inserted
+    // only for a fresh DB. Deleting it here would leave the rebuilt index with no
+    // identity row, so the next open() reads it as a mismatch and needlessly
+    // archives + full-rebuilds a valid index. `since` is intentionally dropped;
+    // the rebuild resets it from "0".
+    clear(): void { this.db.exec("DELETE FROM notes; DELETE FROM index_meta WHERE key <> 'backend_identity';"); }
 
     private filterSql(options: FullTextSearchOptions, alias = "notes") {
         const conditions: string[] = [];

--- a/src/index-lifecycle.test.ts
+++ b/src/index-lifecycle.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { startAfterSuccessfulRebuild } from "./index-lifecycle.js";
+
+describe("index lifecycle", () => {
+    it("starts the live watcher after a successful rebuild", async () => {
+        let starts = 0;
+
+        const started = await startAfterSuccessfulRebuild(Promise.resolve(), () => {
+            starts++;
+        });
+
+        assert.equal(started, true);
+        assert.equal(starts, 1);
+    });
+
+    it("does not start the live watcher after a failed rebuild", async () => {
+        let starts = 0;
+
+        const started = await startAfterSuccessfulRebuild(
+            Promise.reject(new Error("catch-up failed")),
+            () => {
+                starts++;
+            },
+        );
+
+        assert.equal(started, false);
+        assert.equal(starts, 0);
+    });
+
+    it("does not hide watcher startup failures", async () => {
+        await assert.rejects(
+            startAfterSuccessfulRebuild(Promise.resolve(), () => {
+                throw new Error("watcher failed");
+            }),
+            /watcher failed/,
+        );
+    });
+});

--- a/src/index-lifecycle.ts
+++ b/src/index-lifecycle.ts
@@ -1,0 +1,13 @@
+export async function startAfterSuccessfulRebuild(
+    rebuild: Promise<unknown>,
+    start: () => void | Promise<void>,
+): Promise<boolean> {
+    try {
+        await rebuild;
+    } catch {
+        return false;
+    }
+
+    await start();
+    return true;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,20 @@ import { FastMCP } from "fastmcp";
 import { join } from "path";
 import { timingSafeEqual, createHash } from "crypto";
 import { watch, readFileSync, statSync } from "fs";
-import { stat } from "fs/promises";
+import { realpath, stat } from "fs/promises";
 import { setGlobalLogFunction, LEVEL_INFO } from "octagonal-wheels/common/logger";
 import { mountPasswordAuth } from "./auth.js";
-import { SearchIndex } from "./search.js";
+import { planFilesystemIndexSync, SearchIndex } from "./search.js";
 import { applyIndexChange } from "./index-sync.js";
+import { startAfterSuccessfulRebuild } from "./index-lifecycle.js";
+import {
+    deriveFullTextIndexKey,
+    deriveSearchBackendId,
+    FullTextIndex,
+    resolveFullTextSearchSetting,
+    searchIndexStoragePaths,
+    type FullTextSearchSetting,
+} from "./full-text-search.js";
 import { buildAllowedHosts, isHostAllowed, isOriginAllowed } from "./host-guard.js";
 import { registerTools } from "./tools.js";
 import { parseWriteFolders } from "./write-scope.js";
@@ -37,6 +46,7 @@ const BASE_URL = process.env.BASE_URL ?? `http://localhost:${PORT}`;
 const AUTH_TOKEN = process.env.MCP_AUTH_TOKEN;
 const READ_ONLY = process.env.READ_ONLY === "true";
 const WRITE_FOLDERS = parseWriteFolders(process.env.WRITE_FOLDERS);
+const FULL_TEXT_SEARCH = process.env.FULL_TEXT_SEARCH;
 
 // Extra instructions appended to the MCP `instructions` string.
 // File wins if both are set (loud warning); missing file is fatal.
@@ -94,26 +104,87 @@ if (VAULT_PATH) {
 await vault.init();
 console.log("Vault ready.");
 
-// --- Per-vault data directory ---
+// --- Per-backend data directory ---
 const baseDataDir = process.env.DATA_DIR ?? join(process.env.HOME ?? process.env.USERPROFILE ?? "/tmp", ".obsidian-mcp");
-const vaultId = createHash("sha256").update(VAULT_NAME).digest("hex").slice(0, 12);
-const dataDir = join(baseDataDir, vaultId);
+// OAuth persistence stays at its established path; changing search identity
+// must not force unrelated clients to reauthenticate.
+const authDataDir = join(
+    baseDataDir,
+    createHash("sha256").update(VAULT_NAME).digest("hex").slice(0, 12),
+);
+const backendId = VAULT_PATH
+    ? deriveSearchBackendId({ kind: "filesystem", location: await realpath(VAULT_PATH) })
+    : deriveSearchBackendId({ kind: "couchdb", url: COUCHDB_URL!, database: COUCHDB_DATABASE });
+const { indexPath, legacyIndexPath } = searchIndexStoragePaths(baseDataDir, backendId, VAULT_NAME);
 
-// --- Search index ---
-const indexPath = join(dataDir, "search-index.json");
-const searchIndex = new SearchIndex(indexPath, COUCHDB_PASSPHRASE);
-
-// Load persisted metadata from disk
-await searchIndex.loadFromDisk();
-if (debugLogging) {
-    console.log(`[debug] Persisted metadata: ${searchIndex.size} notes, since: ${searchIndex.since || "(none)"}`);
+// --- Search indexes ---
+let fullTextSetting: FullTextSearchSetting;
+try {
+    fullTextSetting = resolveFullTextSearchSetting(
+        FULL_TEXT_SEARCH,
+        Boolean(COUCHDB_URL && COUCHDB_PASSPHRASE),
+    );
+} catch (error) {
+    console.error((error as Error).message);
+    process.exit(1);
 }
+
+let fullTextIndex: FullTextIndex | undefined;
+let fullTextPath: string | undefined;
+if (fullTextSetting.enabled) {
+    // v2 intentionally uses a new file. The v1 database remains available if
+    // the operator rolls back to the previous Docker tag.
+    fullTextPath = indexPath;
+    let unverifiableLegacyIndex = false;
+    try {
+        await stat(legacyIndexPath);
+        unverifiableLegacyIndex = legacyIndexPath !== fullTextPath;
+    } catch {
+        // No VAULT_NAME-scoped prototype index to report.
+    }
+    const encryptionKey = fullTextSetting.encryptIndex
+        ? deriveFullTextIndexKey(COUCHDB_PASSPHRASE!, backendId)
+        : undefined;
+    try {
+        fullTextIndex = await FullTextIndex.open(fullTextPath, {
+            encryptionKey,
+            backendIdentity: backendId,
+        });
+    } finally {
+        encryptionKey?.fill(0);
+    }
+    if (fullTextIndex.migratedFromPlaintext) {
+        console.warn(
+            "Migrated the existing plaintext full-text index to encrypted storage. " +
+            "Old backups or filesystem snapshots may still contain the plaintext copy.",
+        );
+    }
+    if (fullTextIndex.recreatedForSchemaMismatch) {
+        console.warn("Archived an incompatible search index and started a clean v2 rebuild.");
+    }
+    if (fullTextIndex.recreatedForIdentityMismatch) {
+        console.warn("Archived a search index owned by a different backend and started a clean rebuild.");
+    }
+    if (fullTextIndex.createdFresh && unverifiableLegacyIndex) {
+        console.warn(
+            "Found a legacy VAULT_NAME-scoped search index. It was left intact but not reused " +
+            "because its backend identity and checkpoint cannot be verified; rebuilding once.",
+        );
+    }
+    console.log(
+        `Full-text search enabled (local index contains ${fullTextIndex.size} notes, ` +
+        `${fullTextIndex.encryptedAtRest ? "encrypted" : "plaintext"}).`,
+    );
+}
+
+const searchIndex = new SearchIndex(fullTextIndex);
 
 // Sync metadata in background (server starts immediately)
 async function rebuildIndex() {
     const start = performance.now();
 
     if (COUCHDB_URL && vault.catchUp) {
+        searchIndex.setBuildStatus("catching_up", 0, undefined, "Catching up with CouchDB changes.");
         const changeCallback = (path: string, content: string | null, mtime?: number) => {
             // content === "" is an empty-but-present note: index it, don't drop it.
             applyIndexChange(searchIndex, path, content, mtime);
@@ -122,10 +193,27 @@ async function rebuildIndex() {
         let since = searchIndex.since || "0";
         if (debugLogging) console.log(`[debug] CouchDB catch-up from since: ${since}`);
         let changes = 0;
-        const onBatch = async (batchSince: string, processed: number) => {
-            searchIndex.since = batchSince;
-            await searchIndex.saveToDisk();
-            console.log(`  checkpoint: ${processed} changes processed, ${searchIndex.size} notes indexed.`);
+        const catchUpBatched = async (
+            from: string,
+            callback: (path: string, content: string | null, mtime?: number) => void,
+        ) => {
+            searchIndex.beginBatch();
+            try {
+                const result = await vault.catchUp!(from, callback, async (batchSince, processed) => {
+                    // The checkpoint and indexed changes commit atomically.
+                    searchIndex.since = batchSince;
+                    searchIndex.commitBatch();
+                    searchIndex.setBuildStatus("catching_up", processed);
+                    console.log(`  checkpoint: ${processed} changes processed, ${searchIndex.size} notes indexed.`);
+                    await new Promise<void>((resolve) => setImmediate(resolve));
+                    searchIndex.beginBatch();
+                });
+                searchIndex.commitBatch();
+                return result;
+            } catch (error) {
+                searchIndex.rollbackBatch();
+                throw error;
+            }
         };
         try {
             const countingCallback = (path: string, content: string | null, mtime?: number) => {
@@ -133,16 +221,16 @@ async function rebuildIndex() {
                 if (debugLogging) console.log(`[debug] Change: ${path} ${content !== null ? "(update)" : "(delete)"}`);
                 changeCallback(path, content, mtime);
             };
-            const newSince = await vault.catchUp(since, countingCallback, onBatch);
+            const newSince = await catchUpBatched(since, countingCallback);
             searchIndex.since = newSince;
         } catch (err) {
             console.warn(`Catch-up failed (${err}), rebuilding index from scratch...`);
             searchIndex.clear();
             changes = 0;
-            const newSince = await vault.catchUp("0", (path, content, mtime) => {
+            const newSince = await catchUpBatched("0", (path, content, mtime) => {
                 changes++;
                 changeCallback(path, content, mtime);
-            }, onBatch);
+            });
             searchIndex.since = newSince;
         }
         if (changes > 0) {
@@ -151,30 +239,53 @@ async function rebuildIndex() {
             console.log(`Search index up to date (${searchIndex.size} notes).`);
         }
     } else if (VAULT_PATH) {
+        searchIndex.setBuildStatus("building", 0, undefined, "Scanning local vault notes.");
         const notesWithMtime = await vault.listNotesWithMtime();
         if (debugLogging) console.log(`[debug] Vault has ${notesWithMtime.length} notes`);
-        if (notesWithMtime.length > 0) {
-            const vaultPaths = new Set(notesWithMtime.map((n) => n.path));
-            for (const p of searchIndex.listPaths()) {
-                if (!vaultPaths.has(p)) searchIndex.remove(p);
-            }
-            console.log(`Building search index (${notesWithMtime.length} notes)...`);
-            for (let i = 0; i < notesWithMtime.length; i++) {
-                const { path, mtime } = notesWithMtime[i];
-                const content = await vault.readNote(path);
-                // Index empty notes too (content === ""); readNote returns null only if absent.
-                if (content !== null) searchIndex.update(path, content, mtime);
-                if (notesWithMtime.length > 100 && (i + 1) % 500 === 0) {
-                    console.log(`  indexed ${i + 1}/${notesWithMtime.length}...`);
+        const plan = planFilesystemIndexSync(searchIndex.listWithMtime(), notesWithMtime);
+        searchIndex.setBuildStatus("building", 0, plan.read.length, "Indexing changed local vault notes.");
+        for (const path of plan.remove) searchIndex.remove(path);
+        if (plan.read.length > 0) {
+            console.log(
+                `Updating search index (${plan.read.length} changed, ${plan.unchanged} unchanged, ` +
+                `${plan.remove.length} deleted)...`,
+            );
+            searchIndex.beginBatch();
+            try {
+                for (let i = 0; i < plan.read.length; i++) {
+                    const { path, mtime } = plan.read[i];
+                    const content = await vault.readNote(path);
+                    // Index empty notes too (content === ""); readNote returns null only if absent.
+                    if (content !== null) searchIndex.update(path, content, mtime);
+                    else searchIndex.remove(path);
+                    searchIndex.setBuildStatus("building", i + 1, plan.read.length);
+                    if (plan.read.length > 100 && (i + 1) % 500 === 0) {
+                        searchIndex.commitBatch();
+                        console.log(`  indexed ${i + 1}/${plan.read.length} changed notes...`);
+                        await new Promise<void>((resolve) => setImmediate(resolve));
+                        searchIndex.beginBatch();
+                    }
                 }
+                searchIndex.commitBatch();
+            } catch (error) {
+                searchIndex.rollbackBatch();
+                throw error;
             }
-            console.log(`Search index built: ${searchIndex.size} notes in ${((performance.now() - start) / 1000).toFixed(1)}s`);
+            console.log(`Search index updated: ${searchIndex.size} notes in ${((performance.now() - start) / 1000).toFixed(1)}s`);
+        } else {
+            console.log(
+                `Search index up to date (${searchIndex.size} notes; ${plan.remove.length} stale entries removed).`,
+            );
         }
     }
-    await searchIndex.saveToDisk();
+    searchIndex.setBuildStatus("ready", searchIndex.size, searchIndex.size);
 }
-// Fire and forget — server starts while index builds
-rebuildIndex().catch((err) => console.error("Index rebuild failed:", err));
+// Fire and forget — server starts while index builds.
+const rebuildPromise = rebuildIndex();
+void rebuildPromise.catch((err) => {
+    searchIndex.setBuildStatus("error", searchIndex.status.processed, searchIndex.status.total, String(err));
+    console.error("Index rebuild failed:", err);
+});
 
 // --- Watch for external changes ---
 let fsWatcher: ReturnType<typeof watch> | null = null;
@@ -208,14 +319,26 @@ if (VAULT_PATH) {
     }
     console.log("Watching vault for external changes.");
 } else if (COUCHDB_URL && vault.watchChanges) {
-    // Remote mode: watch CouchDB _changes feed for LiveSync updates
-    vault.watchChanges((path: string, content: string | null, mtime?: number, seq?: string | number) => {
-        if (debugLogging) console.log(`[debug] CouchDB ${content === null ? "delete" : "change"}: ${path}`);
-        // content === "" is an empty-but-present note: index it, don't drop it.
-        applyIndexChange(searchIndex, path, content, mtime);
-        if (seq) searchIndex.since = String(seq);
+    // Start the live feed only after catch-up closes its final transaction. The
+    // feed resumes from Vault's last sequence, so changes during catch-up are
+    // not lost and cannot advance the checkpoint out of order.
+    void startAfterSuccessfulRebuild(rebuildPromise, () => {
+        vault.watchChanges!((path: string, content: string | null, mtime?: number, seq?: string | number) => {
+            if (debugLogging) console.log(`[debug] CouchDB ${content === null ? "delete" : "change"}: ${path}`);
+            searchIndex.beginBatch();
+            try {
+                applyIndexChange(searchIndex, path, content, mtime);
+                if (seq) searchIndex.since = String(seq);
+                searchIndex.commitBatch();
+            } catch (error) {
+                searchIndex.rollbackBatch();
+                throw error;
+            }
+        });
+        console.log("Watching CouchDB for LiveSync changes.");
+    }).catch((error) => {
+        console.error("Failed to start CouchDB change watcher:", error);
     });
-    console.log("Watching CouchDB for LiveSync changes.");
 }
 
 // --- MCP Server ---
@@ -278,7 +401,7 @@ if (AUTH_TOKEN) {
 const server = new FastMCP(serverOptions);
 
 if (AUTH_TOKEN) {
-    const tokenPath = join(dataDir, "auth-tokens.json");
+    const tokenPath = join(authDataDir, "auth-tokens.json");
     auth = mountPasswordAuth(server.getApp(), BASE_URL, AUTH_TOKEN, tokenPath);
     await auth.loadTokens();
 }
@@ -290,7 +413,7 @@ registerTools(server, vault, searchIndex, VAULT_NAME, READ_ONLY, WRITE_FOLDERS);
 async function shutdown() {
     console.log("Shutting down...");
     if (fsWatcher) fsWatcher.close();
-    await searchIndex.saveToDisk();
+    searchIndex.close();
     if (auth) await auth.saveTokens();
     await vault.close();
     process.exit(0);
@@ -298,9 +421,8 @@ async function shutdown() {
 process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);
 
-// --- Periodic save (every 5 minutes) ---
+// --- Periodic auth-token cleanup ---
 setInterval(async () => {
-    await searchIndex.saveToDisk();
     if (auth) {
         auth.cleanup();
         await auth.saveTokens();

--- a/src/markdown-chunker.test.ts
+++ b/src/markdown-chunker.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { chunkMarkdown } from "./markdown-chunker.js";
+
+describe("chunkMarkdown", () => {
+    it("removes frontmatter and preserves heading breadcrumbs", () => {
+        const chunks = chunkMarkdown(`---
+tags: [private]
+---
+Preamble text.
+
+# Recovery
+Overview.
+
+## Provider signals
+Look at edge distance.`);
+
+        assert.deepEqual(chunks, [
+            { ordinal: 0, heading: "", breadcrumb: "", body: "Preamble text." },
+            { ordinal: 1, heading: "Recovery", breadcrumb: "Recovery", body: "Overview." },
+            {
+                ordinal: 2,
+                heading: "Provider signals",
+                breadcrumb: "Recovery > Provider signals",
+                body: "Look at edge distance.",
+            },
+        ]);
+        assert.equal(chunks.some((chunk) => chunk.body.includes("private")), false);
+    });
+
+    it("splits very large sections without overlap", () => {
+        const words = Array.from({ length: 1700 }, (_, index) => `word${index}`);
+        const chunks = chunkMarkdown(`# Large\n\n${words.join(" ")}`);
+        assert.equal(chunks.length, 3);
+        assert.ok(chunks.every((chunk) => chunk.body.split(/\s+/).length <= 800));
+        assert.equal(chunks.flatMap((chunk) => chunk.body.split(/\s+/)).length, 1700);
+        assert.ok(chunks.every((chunk) => chunk.breadcrumb === "Large"));
+    });
+});

--- a/src/markdown-chunker.ts
+++ b/src/markdown-chunker.ts
@@ -1,0 +1,105 @@
+/** A compact, deterministic representation of one searchable Markdown section. */
+export interface MarkdownChunk {
+    ordinal: number;
+    heading: string;
+    breadcrumb: string;
+    body: string;
+}
+
+const TARGET_WORDS = 400;
+const MAX_WORDS = 800;
+
+function wordCount(value: string): number {
+    return value.match(/\S+/g)?.length ?? 0;
+}
+
+function stripFrontmatter(content: string): string {
+    if (!content.startsWith("---\n")) return content;
+    const end = content.indexOf("\n---", 4);
+    if (end === -1) return content;
+    const bodyStart = content.indexOf("\n", end + 4);
+    return bodyStart === -1 ? "" : content.slice(bodyStart + 1);
+}
+
+function splitOversizedBody(body: string): string[] {
+    const normalized = body.trim();
+    if (!normalized) return [];
+    if (wordCount(normalized) <= MAX_WORDS) return [normalized];
+
+    const pieces: string[] = [];
+    let current: string[] = [];
+    let currentWords = 0;
+    const paragraphs = normalized.split(/\n\s*\n/).map((part) => part.trim()).filter(Boolean);
+
+    const flush = () => {
+        if (current.length > 0) pieces.push(current.join("\n\n"));
+        current = [];
+        currentWords = 0;
+    };
+
+    for (const paragraph of paragraphs) {
+        const count = wordCount(paragraph);
+        if (count > MAX_WORDS) {
+            flush();
+            const words = paragraph.match(/\S+/g) ?? [];
+            for (let offset = 0; offset < words.length; offset += MAX_WORDS) {
+                pieces.push(words.slice(offset, offset + MAX_WORDS).join(" "));
+            }
+            continue;
+        }
+        if (currentWords >= TARGET_WORDS && currentWords + count > MAX_WORDS) flush();
+        current.push(paragraph);
+        currentWords += count;
+    }
+    flush();
+    return pieces;
+}
+
+/**
+ * Split a note at ATX headings, retaining the heading hierarchy as a breadcrumb.
+ * Large sections are divided at paragraph boundaries without overlap.
+ */
+export function chunkMarkdown(content: string): MarkdownChunk[] {
+    const body = stripFrontmatter(content).replace(/\r\n/g, "\n");
+    const lines = body.split("\n");
+    const headings: string[] = [];
+    const sections: Array<{ heading: string; breadcrumb: string; lines: string[] }> = [];
+    let current = { heading: "", breadcrumb: "", lines: [] as string[] };
+
+    const pushCurrent = () => {
+        if (current.lines.some((line) => line.trim())) sections.push(current);
+    };
+
+    for (const line of lines) {
+        const match = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+        if (!match) {
+            current.lines.push(line);
+            continue;
+        }
+
+        pushCurrent();
+        const level = match[1].length;
+        const heading = match[2].trim();
+        headings.length = level - 1;
+        headings[level - 1] = heading;
+        current = {
+            heading,
+            breadcrumb: headings.filter(Boolean).join(" > "),
+            lines: [],
+        };
+    }
+    pushCurrent();
+
+    const chunks: MarkdownChunk[] = [];
+    for (const section of sections) {
+        for (const piece of splitOversizedBody(section.lines.join("\n"))) {
+            chunks.push({
+                ordinal: chunks.length,
+                heading: section.heading,
+                breadcrumb: section.breadcrumb,
+                body: piece,
+            });
+        }
+    }
+    return chunks;
+}

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -44,6 +44,38 @@ Content`;
         assert.ok(result.tags.includes("important"));
     });
 
+    it("parses inline and multi-line aliases", () => {
+        const content = `---
+aliases:
+  - "Provider recovery"
+  - Stream repair
+alias: [Edge recovery, Playback recovery]
+---`;
+        const result = parseFrontmatterAndLinks(content);
+        assert.deepEqual(result.aliases, [
+            "Provider recovery",
+            "Stream repair",
+            "Edge recovery",
+            "Playback recovery",
+        ]);
+    });
+
+    it("preserves quoted commas in YAML aliases", () => {
+        const result = parseFrontmatterAndLinks(`---
+aliases: ["Smith, John", "Person record"]
+---`);
+        assert.deepEqual(result.aliases, ["Smith, John", "Person record"]);
+    });
+
+    it("preserves unresolved Obsidian template scalars as strings", () => {
+        const result = parseFrontmatterAndLinks(`---
+created: {{date:YYYY-MM-DD}}
+reviewed: {{date:YYYY-MM-DD}} # populated when the template runs
+---`);
+        assert.equal(result.frontmatter.created, "{{date:YYYY-MM-DD}}");
+        assert.equal(result.frontmatter.reviewed, "{{date:YYYY-MM-DD}}");
+    });
+
     it("parses inline #tags", () => {
         const content = "Some text #idea and #project/sub-tag here";
         const result = parseFrontmatterAndLinks(content);
@@ -66,6 +98,8 @@ Also #shared inline`;
         const result = parseFrontmatterAndLinks(content);
         assert.ok(result.links.includes("Other Note"));
         assert.ok(result.links.includes("folder/Linked Note"));
+        assert.ok(result.linkLabels.includes("Other Note"));
+        assert.ok(result.linkLabels.includes("display text"));
     });
 
     it("parses markdown links to .md files", () => {
@@ -73,6 +107,7 @@ Also #shared inline`;
         const result = parseFrontmatterAndLinks(content);
         assert.ok(result.links.includes("other-note.md"));
         assert.ok(result.links.includes("folder/note.md"));
+        assert.ok(result.linkLabels.includes("my link"));
     });
 
     it("ignores non-md markdown links", () => {
@@ -92,11 +127,20 @@ Also #shared inline`;
         assert.deepEqual(result.frontmatter, {});
         assert.deepEqual(result.tags, []);
         assert.deepEqual(result.links, []);
+        assert.deepEqual(result.aliases, []);
+        assert.deepEqual(result.linkLabels, []);
     });
 
     it("handles content with no frontmatter closing delimiter", () => {
         const content = "---\ntitle: Broken\nNo closing delimiter";
         const result = parseFrontmatterAndLinks(content);
         assert.deepEqual(result.frontmatter, {});
+    });
+
+    it("ignores invalid YAML without making the note unindexable", () => {
+        const content = "---\ntags: [unterminated\n---\n# Recovery\nSearchable body #fallback";
+        const result = parseFrontmatterAndLinks(content);
+        assert.deepEqual(result.frontmatter, {});
+        assert.deepEqual(result.tags, ["fallback"]);
     });
 });

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -2,54 +2,63 @@
  * Parse Obsidian markdown content for frontmatter, tags, and links.
  */
 
+import { parse as parseYaml } from "yaml";
+
 export interface NoteMetadata {
     frontmatter: Record<string, string>;
     tags: string[];
     links: string[];
+    aliases: string[];
+    linkLabels: string[];
+}
+
+function stringList(value: unknown): string[] {
+    if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean);
+    if (typeof value !== "string") return value == null ? [] : [String(value)];
+    return value.split(",").map((item) => item.trim()).filter(Boolean);
+}
+
+/**
+ * Obsidian's core Templates plugin commonly leaves scalar placeholders such as
+ * `created: {{date:YYYY-MM-DD}}` in template notes. YAML treats the double
+ * braces as nested flow mappings and emits a process warning while converting
+ * their collection keys to JavaScript strings. Quote only whole scalar values
+ * so the placeholder remains searchable metadata with its original meaning.
+ */
+function preserveObsidianTemplateScalars(yaml: string): string {
+    return yaml.split("\n").map((line) => {
+        const match = line.match(/^(\s*[^#][^:\n]*:\s*)(\{\{.*\}\})(\s*(?:#.*)?)$/);
+        if (!match) return line;
+        return `${match[1]}${JSON.stringify(match[2])}${match[3]}`;
+    }).join("\n");
 }
 
 export function parseFrontmatterAndLinks(content: string): NoteMetadata {
-    const frontmatter: Record<string, any> = {};
+    const frontmatter: Record<string, string> = {};
     const tags = new Set<string>();
     const links: string[] = [];
+    const aliases = new Set<string>();
+    const linkLabels = new Set<string>();
 
     // Parse YAML frontmatter
     if (content.startsWith("---\n")) {
         const end = content.indexOf("\n---", 4);
         if (end !== -1) {
-            const yaml = content.slice(4, end);
-            let inTagsList = false;
-            for (const line of yaml.split("\n")) {
-                // Multi-line tags list item: "  - tagname"
-                if (inTagsList) {
-                    const listItem = line.match(/^\s+-\s+(.+)/);
-                    if (listItem) {
-                        const trimmed = listItem[1].trim();
-                        if (trimmed) tags.add(trimmed);
-                        continue;
-                    }
-                    inTagsList = false;
+            try {
+                const yaml = preserveObsidianTemplateScalars(content.slice(4, end));
+                const parsed = parseYaml(yaml) as Record<string, unknown> | null;
+                for (const [key, value] of Object.entries(parsed ?? {})) {
+                    frontmatter[key] = typeof value === "string" ? value : JSON.stringify(value);
                 }
-
-                const match = line.match(/^(\w[\w-]*)\s*:\s*(.+)/);
-                if (match) {
-                    frontmatter[match[1]] = match[2].trim();
+                for (const tag of stringList(parsed?.tags)) tags.add(tag);
+                for (const alias of [
+                    ...stringList(parsed?.aliases),
+                    ...stringList(parsed?.alias),
+                ]) {
+                    aliases.add(alias);
                 }
-                // Frontmatter tags (inline: [a, b] or start of multi-line list)
-                if (/^tags\s*:/.test(line)) {
-                    const value = line.replace(/^tags\s*:\s*/, "").trim();
-                    if (value) {
-                        // Inline: tags: [a, b] or tags: a, b
-                        const tagValues = value.replace(/[[\]]/g, "");
-                        for (const t of tagValues.split(",")) {
-                            const trimmed = t.trim();
-                            if (trimmed) tags.add(trimmed);
-                        }
-                    } else {
-                        // Multi-line list follows
-                        inTagsList = true;
-                    }
-                }
+            } catch {
+                // Invalid frontmatter must not make the note itself unindexable.
             }
         }
     }
@@ -60,16 +69,25 @@ export function parseFrontmatterAndLinks(content: string): NoteMetadata {
     }
 
     // [[wikilinks]]
-    for (const match of content.matchAll(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g)) {
-        links.push(match[1]);
+    for (const match of content.matchAll(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g)) {
+        const target = match[1].trim();
+        links.push(target);
+        linkLabels.add((match[2] ?? target.split("/").pop() ?? target).trim());
     }
 
     // [markdown links](path.md)
     for (const match of content.matchAll(/\[([^\]]+)\]\(([^)]+\.md)\)/g)) {
         links.push(match[2]);
+        linkLabels.add(match[1].trim());
     }
 
-    return { frontmatter, tags: [...tags], links: [...new Set(links)] };
+    return {
+        frontmatter,
+        tags: [...tags],
+        links: [...new Set(links)],
+        aliases: [...aliases],
+        linkLabels: [...linkLabels].filter(Boolean),
+    };
 }
 
 export function extractSnippet(content: string, query: string, context = 80): string {

--- a/src/search.test.ts
+++ b/src/search.test.ts
@@ -3,7 +3,8 @@ import assert from "node:assert/strict";
 import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
-import { SearchIndex } from "./search.js";
+import { planFilesystemIndexSync, SearchIndex } from "./search.js";
+import { FullTextIndex } from "./full-text-search.js";
 
 let tmpDir: string;
 
@@ -16,6 +17,56 @@ after(async () => {
 });
 
 describe("SearchIndex", () => {
+    it("plans local startup reads only for new or mtime-changed notes", () => {
+        const plan = planFilesystemIndexSync(
+            [
+                { path: "unchanged.md", mtime: 100 },
+                { path: "same-content-new-mtime.md", mtime: 100 },
+                { path: "deleted.md", mtime: 50 },
+            ],
+            [
+                { path: "unchanged.md", mtime: 100 },
+                { path: "same-content-new-mtime.md", mtime: 200 },
+                { path: "new.md", mtime: 300 },
+            ],
+        );
+        assert.deepEqual(plan, {
+            remove: ["deleted.md"],
+            read: [
+                { path: "same-content-new-mtime.md", mtime: 200 },
+                { path: "new.md", mtime: 300 },
+            ],
+            unchanged: 1,
+        });
+    });
+
+    it("removes every persisted note when the local vault becomes empty", () => {
+        assert.deepEqual(planFilesystemIndexSync([
+            { path: "a.md", mtime: 1 },
+            { path: "b.md", mtime: 2 },
+        ], []), {
+            remove: ["a.md", "b.md"],
+            read: [],
+            unchanged: 0,
+        });
+    });
+
+    it("routes metadata updates and deletes into the full-text index", async () => {
+        const fullText = await FullTextIndex.open(":memory:");
+        const idx = new SearchIndex(fullText);
+        try {
+            idx.update("note.md", "provider recovery evidence", 100);
+            assert.deepEqual(
+                idx.searchNotes({ query: "provider" }).map((result) => result.path),
+                ["note.md"],
+            );
+            idx.remove("note.md");
+            assert.equal(idx.searchNotes({ query: "provider" }).length, 0);
+        } finally {
+            idx.close();
+        }
+    });
+
     it("tracks size correctly", () => {
         const idx = new SearchIndex();
         assert.equal(idx.size, 0);
@@ -126,18 +177,18 @@ describe("SearchIndex", () => {
     });
 });
 
-describe("SearchIndex persistence", () => {
-    it("saves and loads mtimes and tags from disk", async () => {
-        const path = join(tmpDir, "index.json");
-
-        const idx1 = new SearchIndex(path);
+describe("SearchIndex SQLite persistence", () => {
+    it("persists metadata, links, and the checkpoint in the search database", async () => {
+        const path = join(tmpDir, "index.sqlite");
+        const firstDb = await FullTextIndex.open(path);
+        const idx1 = new SearchIndex(firstDb);
         idx1.update("note1.md", "---\ntags: [foo]\n---\nHello world", 100);
         idx1.update("note2.md", "Goodbye world, see [[note1]]", 200);
-        await idx1.saveToDisk();
+        idx1.since = "checkpoint-42";
+        idx1.close();
 
-        const idx2 = new SearchIndex(path);
-        const loaded = await idx2.loadFromDisk();
-        assert.ok(loaded);
+        const secondDb = await FullTextIndex.open(path);
+        const idx2 = new SearchIndex(secondDb);
         assert.equal(idx2.size, 2);
 
         const notes = idx2.listWithMtime();
@@ -150,36 +201,23 @@ describe("SearchIndex persistence", () => {
 
         // Backlinks survive persistence
         assert.deepEqual(idx2.getBacklinks("note1.md"), ["note2.md"]);
-
-        // Metadata survives persistence (no FlexSearch)
+        assert.equal(idx2.since, "checkpoint-42");
+        idx2.close();
     });
 
-    it("saves and loads encrypted when passphrase set", async () => {
-        const path = join(tmpDir, "encrypted-index.json");
-
-        const idx1 = new SearchIndex(path, "mypassphrase");
-        idx1.update("secret.md", "classified content", 999);
-        await idx1.saveToDisk();
-
-        // Verify file is not plaintext
-        const { readFile } = await import("fs/promises");
-        const raw = await readFile(path, "utf-8");
-        assert.ok(!raw.includes("secret.md"));
-        assert.ok(!raw.includes("classified"));
-
-        const idx2 = new SearchIndex(path, "mypassphrase");
-        const loaded = await idx2.loadFromDisk();
-        assert.ok(loaded);
-        assert.equal(idx2.size, 1);
-    });
-
-    it("returns false when no persisted index exists", async () => {
-        const idx = new SearchIndex(join(tmpDir, "nonexistent.json"));
-        assert.equal(await idx.loadFromDisk(), false);
-    });
-
-    it("returns false when no persist path configured", async () => {
-        const idx = new SearchIndex();
-        assert.equal(await idx.loadFromDisk(), false);
+    it("reports build progress with current note and chunk counts", async () => {
+        const db = await FullTextIndex.open(":memory:");
+        const idx = new SearchIndex(db);
+        idx.update("note.md", "# Heading\n\nBody", 1);
+        idx.setBuildStatus("building", 1, 4);
+        assert.deepEqual(idx.status, {
+            state: "building",
+            processed: 1,
+            total: 4,
+            message: undefined,
+            notes: 1,
+            chunks: 1,
+        });
+        idx.close();
     });
 });

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,122 +1,69 @@
-/**
- * Metadata index for vault notes.
- *
- * Tracks paths, mtimes, tags, links, and backlinks.
- * Persists to disk (encrypted if passphrase is set).
- * No full-text search — metadata only.
- */
+/** Metadata access and search facade, backed by SQLite when search is enabled. */
 
-import { readFile, writeFile, mkdir, chmod } from "fs/promises";
-import { dirname } from "path";
-import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "crypto";
 import { parseFrontmatterAndLinks } from "./parse.js";
+import type { FullTextIndex, FullTextSearchOptions, FullTextSearchResult } from "./full-text-search.js";
 
-
-function encrypt(text: string, passphrase: string): string {
-    const salt = randomBytes(16);
-    const key = scryptSync(passphrase, salt, 32);
-    const iv = randomBytes(12);
-    const cipher = createCipheriv("aes-256-gcm", key, iv);
-    const encrypted = Buffer.concat([cipher.update(text, "utf-8"), cipher.final()]);
-    const tag = (cipher as any).getAuthTag() as Buffer;
-    return salt.toString("hex") + ":" + iv.toString("hex") + ":" + tag.toString("hex") + ":" + encrypted.toString("hex");
+export type SearchBuildState = "ready" | "building" | "catching_up" | "error";
+export interface SearchBuildStatus {
+    state: SearchBuildState;
+    processed: number;
+    total?: number;
+    message?: string;
+    notes: number;
+    chunks: number;
 }
 
-function decrypt(data: string, passphrase: string): string {
-    const [saltHex, ivHex, tagHex, encryptedHex] = data.split(":");
-    const key = scryptSync(passphrase, Buffer.from(saltHex, "hex"), 32);
-    const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(ivHex, "hex"));
-    (decipher as any).setAuthTag(Buffer.from(tagHex, "hex"));
-    return Buffer.concat([decipher.update(Buffer.from(encryptedHex, "hex")), decipher.final()]).toString("utf-8");
+export interface IndexedNoteListing { path: string; mtime: number }
+export interface FilesystemIndexSyncPlan {
+    remove: string[];
+    read: IndexedNoteListing[];
+    unchanged: number;
+}
+
+/** Plan a local startup reconciliation without reading unchanged note bodies. */
+export function planFilesystemIndexSync(
+    indexedNotes: IndexedNoteListing[],
+    vaultNotes: IndexedNoteListing[],
+): FilesystemIndexSyncPlan {
+    const indexed = new Map(indexedNotes.map((note) => [note.path, note.mtime]));
+    const vaultPaths = new Set(vaultNotes.map((note) => note.path));
+    const remove = indexedNotes
+        .filter((note) => !vaultPaths.has(note.path))
+        .map((note) => note.path)
+        .sort();
+    const read = vaultNotes.filter((note) => indexed.get(note.path) !== note.mtime);
+    return { remove, read, unchanged: vaultNotes.length - read.length };
 }
 
 export class SearchIndex {
+    // Used only when FULL_TEXT_SEARCH=false. The normal path keeps metadata in SQLite.
     private mtimes = new Map<string, number>();
     private tags = new Map<string, string[]>();
     private links = new Map<string, string[]>();
     private backlinks = new Map<string, Set<string>>();
     private knownPaths = new Set<string>();
-    private saving = false;
-    private _since: string = "";
-    private persistPath: string | null;
-    private passphrase: string | null;
+    private _since = "";
+    private fullTextIndex: FullTextIndex | null;
+    private buildState: Omit<SearchBuildStatus, "notes" | "chunks"> = {
+        state: "ready",
+        processed: 0,
+    };
 
-    constructor(persistPath?: string, passphrase?: string) {
-        this.persistPath = persistPath ?? null;
-        this.passphrase = passphrase ?? null;
+    constructor(fullTextIndex?: FullTextIndex) {
+        this.fullTextIndex = fullTextIndex ?? null;
     }
 
-    /** Load metadata from disk. */
-    async loadFromDisk(): Promise<boolean> {
-        if (!this.persistPath) return false;
-        try {
-            let raw = await readFile(this.persistPath, "utf-8");
-            if (this.passphrase) {
-                raw = decrypt(raw, this.passphrase);
-            }
-            const data = JSON.parse(raw);
-            for (const [path, mtime] of Object.entries(data.mtimes ?? {})) {
-                this.mtimes.set(path, mtime as number);
-                this.knownPaths.add(path);
-            }
-            for (const [path, t] of Object.entries(data.tags ?? {})) {
-                this.tags.set(path, t as string[]);
-            }
-            for (const [path, l] of Object.entries(data.links ?? {})) {
-                const targets = l as string[];
-                this.links.set(path, targets);
-                for (const target of targets) {
-                    const key = target.toLowerCase();
-                    if (!this.backlinks.has(key)) this.backlinks.set(key, new Set());
-                    this.backlinks.get(key)!.add(path);
-                }
-            }
-            if (data.since) this._since = data.since;
-            console.log(`Search metadata loaded from disk (${this.knownPaths.size} notes, since: ${this._since ? "yes" : "none"}).`);
-            return this.knownPaths.size > 0;
-        } catch {
-            return false;
-        }
-    }
-
-    /** Save metadata to disk. Encrypted if passphrase is set. */
-    async saveToDisk(): Promise<void> {
-        if (!this.persistPath || this.saving) return;
-        this.saving = true;
-        try {
-            await mkdir(dirname(this.persistPath), { recursive: true });
-            let data = JSON.stringify({
-                mtimes: Object.fromEntries(this.mtimes),
-                tags: Object.fromEntries(this.tags),
-                links: Object.fromEntries(this.links),
-                since: this._since,
-            });
-            if (this.passphrase) {
-                data = encrypt(data, this.passphrase);
-            }
-            await writeFile(this.persistPath, data, { encoding: "utf-8", mode: 0o600 });
-            await chmod(this.persistPath, 0o600);
-            console.log(`Search index saved to disk (${this.knownPaths.size} notes${this.passphrase ? ", encrypted" : ""}).`);
-        } catch (err) {
-            console.error("Failed to save search index:", err);
-        } finally {
-            this.saving = false;
-        }
-    }
-
-    /** Add or update a note in the index. */
     update(path: string, content: string, mtime?: number): void {
-        if (this.knownPaths.has(path)) {
-            this.clearBacklinks(path);
+        if (this.fullTextIndex) {
+            this.fullTextIndex.update(path, content, mtime);
+            return;
         }
+        if (this.knownPaths.has(path)) this.clearBacklinks(path);
         this.knownPaths.add(path);
         if (mtime !== undefined) this.mtimes.set(path, mtime);
         const parsed = parseFrontmatterAndLinks(content);
-        if (parsed.tags.length > 0) {
-            this.tags.set(path, parsed.tags);
-        } else {
-            this.tags.delete(path);
-        }
+        if (parsed.tags.length > 0) this.tags.set(path, parsed.tags);
+        else this.tags.delete(path);
         if (parsed.links.length > 0) {
             this.links.set(path, parsed.links);
             for (const target of parsed.links) {
@@ -124,13 +71,14 @@ export class SearchIndex {
                 if (!this.backlinks.has(key)) this.backlinks.set(key, new Set());
                 this.backlinks.get(key)!.add(path);
             }
-        } else {
-            this.links.delete(path);
-        }
+        } else this.links.delete(path);
     }
 
-    /** Remove a note from the index. */
     remove(path: string): void {
+        if (this.fullTextIndex) {
+            this.fullTextIndex.remove(path);
+            return;
+        }
         if (this.knownPaths.has(path)) {
             this.knownPaths.delete(path);
             this.mtimes.delete(path);
@@ -139,7 +87,6 @@ export class SearchIndex {
         }
     }
 
-    /** Remove all backlink entries where path is the source. */
     private clearBacklinks(path: string): void {
         const oldLinks = this.links.get(path);
         if (oldLinks) {
@@ -152,81 +99,87 @@ export class SearchIndex {
         this.links.delete(path);
     }
 
-    /** List all indexed paths, optionally filtered by folder prefix. */
-    listPaths(folder?: string): string[] {
-        return this.listWithMtime(folder).map((n) => n.path);
-    }
-
-    /** List all indexed paths with mtimes, optionally filtered by folder prefix. */
+    listPaths(folder?: string): string[] { return this.listWithMtime(folder).map((note) => note.path); }
     listWithMtime(folder?: string): Array<{ path: string; mtime: number }> {
-        const prefix = folder && !folder.endsWith("/") ? folder + "/" : folder;
-        const entries = [...this.knownPaths]
-            .filter((p) => p.endsWith(".md"))
-            .filter((p) => !prefix || p.startsWith(prefix))
-            .map((p) => ({ path: p, mtime: this.mtimes.get(p) ?? 0 }));
-        return entries.sort((a, b) => a.path.localeCompare(b.path));
+        if (this.fullTextIndex) return this.fullTextIndex.listWithMtime(folder);
+        const prefix = folder && !folder.endsWith("/") ? `${folder}/` : folder;
+        return [...this.knownPaths]
+            .filter((path) => path.endsWith(".md"))
+            .filter((path) => !prefix || path.startsWith(prefix))
+            .map((path) => ({ path, mtime: this.mtimes.get(path) ?? 0 }))
+            .sort((left, right) => left.path.localeCompare(right.path));
     }
-
-    /** Get mtime for a path. */
     getMtime(path: string): number {
-        return this.mtimes.get(path) ?? 0;
+        return this.fullTextIndex?.getMtime(path) ?? this.mtimes.get(path) ?? 0;
     }
-
-    /** Get tags for a path. */
-    getTags(path: string): string[] {
-        return this.tags.get(path) ?? [];
-    }
-
-    /** Get outgoing links for a path. */
-    getLinks(path: string): string[] {
-        return this.links.get(path) ?? [];
-    }
-
-    /** Get backlinks for a path (notes that link to it). Case-insensitive, matches by full path or filename. */
+    getTags(path: string): string[] { return this.fullTextIndex?.getTags(path) ?? this.tags.get(path) ?? []; }
+    getLinks(path: string): string[] { return this.fullTextIndex?.getLinks(path) ?? this.links.get(path) ?? []; }
     getBacklinks(path: string): string[] {
+        if (this.fullTextIndex) return this.fullTextIndex.getBacklinks(path);
         const results = new Set<string>();
-        const withMd = (path.endsWith(".md") ? path : path + ".md").toLowerCase();
+        const withMd = (path.endsWith(".md") ? path : `${path}.md`).toLowerCase();
         const withoutMd = (path.endsWith(".md") ? path.slice(0, -3) : path).toLowerCase();
-        const nameOnly = withoutMd.includes("/") ? withoutMd.slice(withoutMd.lastIndexOf("/") + 1) : withoutMd;
-
+        const nameOnly = withoutMd.includes("/")
+            ? withoutMd.slice(withoutMd.lastIndexOf("/") + 1)
+            : withoutMd;
         for (const target of [withMd, withoutMd, nameOnly]) {
-            const sources = this.backlinks.get(target);
-            if (sources) {
-                for (const s of sources) results.add(s);
-            }
+            for (const source of this.backlinks.get(target) ?? []) results.add(source);
         }
         return [...results].sort();
     }
-
-    /** List all tags across the vault with counts. */
     listAllTags(): Array<{ tag: string; count: number }> {
+        if (this.fullTextIndex) return this.fullTextIndex.listAllTags();
         const counts = new Map<string, number>();
-        for (const tags of this.tags.values()) {
-            for (const t of tags) {
-                counts.set(t, (counts.get(t) ?? 0) + 1);
-            }
+        for (const noteTags of this.tags.values()) {
+            for (const tag of noteTags) counts.set(tag, (counts.get(tag) ?? 0) + 1);
         }
         return [...counts.entries()]
             .map(([tag, count]) => ({ tag, count }))
-            .sort((a, b) => b.count - a.count);
+            .sort((left, right) => right.count - left.count || left.tag.localeCompare(right.tag));
     }
 
-    /** Clear all index data (for full rebuild after DB nuke). */
     clear(): void {
-        const paths = Array.from(this.knownPaths);
-        for (const p of paths) this.remove(p);
+        if (this.fullTextIndex) {
+            this.fullTextIndex.clear();
+            return;
+        }
+        this.mtimes.clear();
+        this.tags.clear();
+        this.links.clear();
+        this.backlinks.clear();
+        this.knownPaths.clear();
         this._since = "";
     }
-
-    get since(): string {
-        return this._since;
+    beginBatch(): void { this.fullTextIndex?.beginBatch(); }
+    commitBatch(): void { this.fullTextIndex?.commitBatch(); }
+    rollbackBatch(): void { this.fullTextIndex?.rollbackBatch(); }
+    searchNotes(options: FullTextSearchOptions): FullTextSearchResult[] {
+        return this.fullTextIndex?.search(options) ?? [];
     }
 
+    setBuildStatus(
+        state: SearchBuildState,
+        processed = this.buildState.processed,
+        total?: number,
+        message?: string,
+    ): void {
+        this.buildState = { state, processed, total, message };
+    }
+    get status(): SearchBuildStatus {
+        return {
+            ...this.buildState,
+            notes: this.size,
+            chunks: this.fullTextIndex?.chunkCount ?? 0,
+        };
+    }
+    get fullTextEnabled(): boolean { return this.fullTextIndex !== null; }
+    get fullTextSize(): number { return this.fullTextIndex?.size ?? 0; }
+    get fullTextCreatedFresh(): boolean { return this.fullTextIndex?.createdFresh ?? false; }
+    close(): void { this.fullTextIndex?.close(); }
+    get since(): string { return this.fullTextIndex?.checkpoint ?? this._since; }
     set since(value: string) {
-        this._since = value;
+        if (this.fullTextIndex) this.fullTextIndex.checkpoint = value;
+        else this._since = value;
     }
-
-    get size(): number {
-        return this.knownPaths.size;
-    }
+    get size(): number { return this.fullTextIndex?.size ?? this.knownPaths.size; }
 }

--- a/src/tools.test.ts
+++ b/src/tools.test.ts
@@ -1,0 +1,37 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { SearchBuildStatus } from "./search.js";
+import { formatIndexStatusNotice } from "./tools.js";
+
+function status(
+    state: SearchBuildStatus["state"],
+    processed = 0,
+    total?: number,
+): SearchBuildStatus {
+    return { state, processed, total, notes: processed, chunks: processed };
+}
+
+describe("index-backed tool status notices", () => {
+    it("is silent only when the index is ready", () => {
+        assert.equal(formatIndexStatusNotice(status("ready")), "");
+    });
+
+    it("labels initial-build results and counts as incomplete", () => {
+        const notice = formatIndexStatusNotice(status("building", 1, 4));
+        assert.match(notice, /building \(25% complete\)/);
+        assert.match(notice, /results, counts, and backlinks are incomplete/);
+    });
+
+    it("labels catch-up results as potentially missing recent changes", () => {
+        const notice = formatIndexStatusNotice(status("catching_up", 12));
+        assert.match(notice, /catching up \(12 changes processed\)/);
+        assert.match(notice, /may omit recent changes/);
+    });
+
+    it("labels failed updates as stale or incomplete without exposing errors", () => {
+        const failed = { ...status("error"), message: "/private/vault/path failed" };
+        const notice = formatIndexStatusNotice(failed);
+        assert.match(notice, /stale or incomplete/);
+        assert.doesNotMatch(notice, /private|vault|path failed/);
+    });
+});

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,12 +2,30 @@ import type { FastMCP } from "fastmcp";
 import { z } from "zod";
 import { makeDeepLink } from "./deeplink.js";
 import type { VaultBackend } from "./vault-backend.js";
-import type { SearchIndex } from "./search.js";
+import type { SearchBuildStatus, SearchIndex } from "./search.js";
 import { isPathWritable } from "./write-scope.js";
 
 const debugLogging = process.env.LOG_LEVEL === "debug";
 
 const WRITE_TOOLS = ["write_note", "edit_note", "delete_note", "move_note"] as const;
+
+export function formatIndexStatusNotice(status: SearchBuildStatus): string {
+    if (status.state === "ready") return "";
+    if (status.state === "error") {
+        return "⚠ Search index update failed. Index-backed results, counts, and backlinks may be stale or incomplete.";
+    }
+    const progress = status.total && status.total > 0
+        ? ` (${Math.min(100, Math.round(status.processed / status.total * 100))}% complete)`
+        : status.processed > 0 ? ` (${status.processed} changes processed)` : "";
+    return status.state === "building"
+        ? `⚠ Search index is building${progress}. Index-backed results, counts, and backlinks are incomplete.`
+        : `⚠ Search index is catching up${progress}. Index-backed results, counts, and backlinks may omit recent changes.`;
+}
+
+function withIndexStatusNotice(value: string, searchIndex: SearchIndex): string {
+    const notice = formatIndexStatusNotice(searchIndex.status);
+    return notice ? `${notice}\n\n${value}` : value;
+}
 
 export function registerTools(
     server: FastMCP,
@@ -124,7 +142,10 @@ export function registerTools(
                 notes = notes.filter((n) => n.mtime >= cutoff);
             }
             if (notes.length === 0) {
-                return folder ? `No notes found in folder: ${folder}` : "Vault is empty.";
+                const empty = searchIndex.status.state === "ready"
+                    ? (folder ? `No notes found in folder: ${folder}` : "Vault is empty.")
+                    : (folder ? `No indexed notes found in folder: ${folder}` : "No indexed notes are available yet.");
+                return withIndexStatusNotice(empty, searchIndex);
             }
             if (sort_by === "modified") {
                 notes.sort((a, b) => b.mtime - a.mtime);
@@ -140,7 +161,79 @@ export function registerTools(
             if (total > cap) {
                 lines.push(`\n... and ${total - cap} more. Use a folder filter or limit to narrow results.`);
             }
-            return lines.join("\n");
+            return withIndexStatusNotice(lines.join("\n"), searchIndex);
+        },
+    });
+
+    if (searchIndex.fullTextEnabled) server.addTool({
+        name: "search_notes",
+        description:
+            "Search note titles, aliases, headings, tags, and body text using the disk-backed full-text index. Returns ranked paths with matching snippets. Exact title, alias, filename, and path matches rank first, so a known note name is a good query. Use list_notes only to browse a folder or tag without a text query.",
+        parameters: z.object({
+            query: z
+                .string()
+                .describe("Words or phrase to find in note content and metadata."),
+            folder: z
+                .string()
+                .optional()
+                .describe("Restrict results to this vault-relative folder."),
+            tag: z
+                .string()
+                .optional()
+                .describe("Require this exact tag in addition to the text query."),
+            modified_after: z
+                .string()
+                .optional()
+                .describe("Only include notes modified after this ISO date."),
+            mode: z
+                .enum(["all", "any", "phrase"])
+                .optional()
+                .describe("Match all words (default), any word, or the exact token phrase."),
+            limit: z.coerce
+                .number()
+                .int()
+                .min(1)
+                .max(50)
+                .optional()
+                .describe("Maximum ranked results. Default 10; maximum 50."),
+        }),
+        execute: async ({ query, folder, tag, modified_after, mode, limit }) => {
+            let modifiedAfter: number | undefined;
+            if (modified_after) {
+                modifiedAfter = new Date(modified_after).getTime();
+                if (isNaN(modifiedAfter)) {
+                    return `Invalid date format: ${modified_after}. Use ISO format like '2026-03-25'.`;
+                }
+            }
+
+            try {
+                const status = searchIndex.status;
+                const statusNotice = formatIndexStatusNotice(status);
+                const results = searchIndex.searchNotes({
+                    query,
+                    folder,
+                    tag,
+                    modifiedAfter,
+                    mode,
+                    limit,
+                });
+                if (results.length === 0) {
+                    return `${statusNotice ? `${statusNotice}\n\n` : ""}No notes found matching: ${query}`;
+                }
+
+                const rendered = results.map((result) => {
+                    const deepLink = makeDeepLink(vaultName, result.path);
+                    const date = result.mtime
+                        ? ` (${new Date(result.mtime).toISOString().slice(0, 10)})`
+                        : "";
+                    const location = result.breadcrumb ? ` — ${result.breadcrumb}` : "";
+                    const snippet = result.snippet ? `\n  ${result.snippet}` : "";
+                    return `- [${result.path}](${deepLink})${date}${location}${snippet}`;
+                }).join("\n");
+                return statusNotice ? `${statusNotice}\n\n${rendered}` : rendered;
+            } catch (error) {
+                return `Invalid search query: ${(error as Error).message}`;
+            }
         },
     });
 
@@ -171,10 +264,16 @@ export function registerTools(
                 }
             }
             if (folders.size === 0) {
-                return "Vault is empty.";
+                const empty = searchIndex.status.state === "ready"
+                    ? "Vault is empty."
+                    : "No indexed folders are available yet.";
+                return withIndexStatusNotice(empty, searchIndex);
             }
             const sorted = [...folders.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-            return sorted.map(([f, count]) => `- ${f} (${count} notes)`).join("\n");
+            return withIndexStatusNotice(
+                sorted.map(([f, count]) => `- ${f} (${count} notes)`).join("\n"),
+                searchIndex,
+            );
         },
     });
 
@@ -186,9 +285,15 @@ export function registerTools(
         execute: async () => {
             const tags = searchIndex.listAllTags();
             if (tags.length === 0) {
-                return "No tags found in the vault.";
+                const empty = searchIndex.status.state === "ready"
+                    ? "No tags found in the vault."
+                    : "No indexed tags are available yet.";
+                return withIndexStatusNotice(empty, searchIndex);
             }
-            return tags.map(({ tag, count }) => `- #${tag} (${count} notes)`).join("\n");
+            return withIndexStatusNotice(
+                tags.map(({ tag, count }) => `- #${tag} (${count} notes)`).join("\n"),
+                searchIndex,
+            );
         },
     });
 
@@ -331,7 +436,7 @@ export function registerTools(
                 lines.push(`\nBacklinks: ${backlinks.join(", ")}`);
             }
             lines.push(`\n[Open in Obsidian](${deepLink})`);
-            return lines.join("\n");
+            return withIndexStatusNotice(lines.join("\n"), searchIndex);
         },
     });
 }

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -297,9 +297,9 @@ describe("E2E: MCP_INSTRUCTIONS", () => {
 
 describe("E2E: cold restart with persisted index", () => {
     it("picks up changes and removes stale entries after restart", async () => {
-        // Stop server (triggers saveToDisk)
+        // Stop server (closes SQLite and flushes auth state)
         const firstLogs = await stopServer();
-        assert.ok(firstLogs.includes("Search index saved"), "Should save index on shutdown");
+        assert.ok(firstLogs.includes("Shutting down..."), "Should shut down cleanly");
 
         // Modify vault while server is down (simulates Obsidian edits)
         await writeFile(join(vaultDir, "new-while-down.md"), "# Created while MCP was down\nfreshcontent");
@@ -309,18 +309,19 @@ describe("E2E: cold restart with persisted index", () => {
         // Restart server
         await startServer({ VAULT_PATH: vaultDir, VAULT_NAME: "TestVault" });
 
-        // The server accepts connections while the index rebuild runs in the
-        // background — wait for the rebuild to finish before asserting.
+        // The server accepts connections while index reconciliation runs in the
+        // background — wait for the incremental update to finish before asserting.
         const deadline = Date.now() + 5000;
-        while (Date.now() < deadline && !serverLogs.includes("Search index built")) {
+        while (Date.now() < deadline && !serverLogs.includes("Search index updated")) {
             await new Promise((r) => setTimeout(r, 50));
         }
         const restartLogs = serverLogs;
 
-        // Should rebuild search index from vault files
+        // Only the two new/changed bodies should be read; the removed path is
+        // reconciled from the persisted path set.
         assert.ok(
-            restartLogs.includes("Search index built") || restartLogs.includes("Search metadata loaded"),
-            "Should rebuild index on restart",
+            restartLogs.includes("Updating search index (2 changed") && restartLogs.includes("1 deleted"),
+            `Should incrementally reconcile two changed notes and one deletion\n${restartLogs}`,
         );
 
         // New note should be listed


### PR DESCRIPTION
## Summary

- Restore full-text vault search with a disk-backed SQLite/FTS5 index instead of rebuilding note bodies into the JavaScript heap on every cold start.
- Rank exact title, alias, filename, and path matches alongside heading-aware stemmed passage matches, with folder, tag, date, mode, and limit filters.
- Persist metadata, links, backlinks, and CouchDB checkpoints transactionally so local and remote startup are incremental.
- Encrypt the derived search index for encrypted CouchDB vaults and document storage, migration, recovery, compatibility, and rollback behavior.

## Why

Filename-only `list_notes` discovery is not enough for an agent trying to find a concept when it does not already know the note name.

The previous FlexSearch implementation provided body search, but project history records a 53 MiB persisted index that caused out-of-memory failures on load, a full rebuild on cold start, and eventual removal of full-text search in v0.5.0. This change restores the capability with bounded, persisted native storage rather than returning note bodies to a long-lived JavaScript index.

## Design

- SQLite owns note metadata, normalized aliases, tags, links, heading-level chunks, and the last CouchDB sequence.
- FTS5 uses Unicode tokenization and Porter stemming. Exact metadata and BM25 passage lanes are combined with reciprocal-rank fusion and return one result per note.
- Filesystem startup compares persisted mtimes and reads only new or changed bodies; missing paths are removed, including when the vault becomes empty.
- CouchDB catch-up commits indexed changes and checkpoints in cooperative transactions. The live watcher starts only after catch-up succeeds.
- Search-backed reads disclose initial-build, catch-up, and failed-update state instead of presenting incomplete results as complete.
- Storage identity is derived from the canonical filesystem root or normalized CouchDB URL plus database name. It does not depend on the display-only `VAULT_NAME`.

## Security and recovery

Encrypted remote vaults derive a vault-specific index key with scrypt followed by HKDF and open the database through SQLCipher-compatible SQLite. Plain local or unencrypted vaults use plaintext SQLite, which is called out explicitly in the documentation.

Tests inspect the database, rollback journal, temporary files, schema backups, and migration outputs for note plaintext and private file modes. Wrong keys fail closed. Existing plaintext and prototype encrypted indexes migrate forward; incompatible schema or backend identity is archived and rebuilt. The previous index is left intact where ownership cannot be verified, and the change can be rolled back without modifying vault content.

## Performance evidence

The committed deterministic harness covers exact-title, exact-alias, rare-passage, filtered, phrase, and broad queries. Reference Linux x64 results:

| Notes | Index | Build | Query p95 | Update p95 | Index | RSS |
|---:|:---|---:|---:|---:|---:|---:|
| 10k | plaintext | 2.20 s | 23.22 ms | 8.52 ms | 19.39 MiB | 152.93 MiB |
| 10k | encrypted | 2.50 s | 23.23 ms | 9.30 ms | 20.02 MiB | 135.07 MiB |
| 50k | plaintext | 14.12 s | 98.60 ms | 9.15 ms | 99.90 MiB | 240.45 MiB |
| 50k | encrypted | 17.65 s | 176.81 ms | 10.10 ms | 103.63 MiB | 240.52 MiB |
| 100k | plaintext | 29.20 s | 206.82 ms | 9.00 ms | 198.95 MiB | 283.98 MiB |
| 100k | encrypted | 38.67 s | 384.28 ms | 10.54 ms | 206.47 MiB | 284.64 MiB |

Raw JSON, runtime and hardware details, reproduction commands, and regression budgets are in `benchmarks/`.

The encrypted remote candidate also completed at least 48 hours of combined soak coverage. The final 19-hour-40-minute segment remained ready with a checkpoint for 237 samples, resumed 197 notes and 1,601 chunks in about 26 ms after restart, and passed live create, edit, move, delete, empty-note, wrong-passphrase, and rollback checks.

## Configuration and compatibility

- `FULL_TEXT_SEARCH=auto` and `true` enable the index; `false` keeps metadata in memory and replays CouchDB changes after restart.
- Node 22.14+ on the Node 22 line and Node 24 are supported. Node 22.13 crashes inside the native SQLite dependency and is rejected by `engines`.
- The bundled native prebuilds were smoke-tested on Linux amd64 and arm64. Repository installs use `npm ci --ignore-scripts` to avoid npm's unnecessary implicit `node-gyp rebuild`.
- The PR deliberately excludes stateless transport, session instrumentation, OAuth redesign, broader agent API changes, and soak-only telemetry.

## Validation

- [x] Clean `npm ci --ignore-scripts`, `npm test` (173), and `npm run build` on Node 22.14.0
- [x] Clean `npm ci --ignore-scripts`, `npm test` (173), and `npm run build` on Node 24
- [x] `npm run test:e2e` (27)
- [x] `npm run test:couchdb` against disposable CouchDB 3
- [x] `npm run lint`
- [x] `npm pack --dry-run`
- [x] Linux amd64 and arm64 production-image build and startup smoke tests
- [x] Plaintext and encrypted benchmarks at 10k, 50k, and 100k notes
- [x] `npm audit --audit-level=high` (passes; remaining low `esbuild` dev-server and moderate buffered-`uuid` findings have no exercised vulnerable path here and no non-breaking upstream resolution)
- [x] `git diff --check`

## Review focus

The most consequential review areas are index key derivation and migration, checkpoint transaction boundaries, backend identity, and the operational tradeoff of adding a native SQLite dependency.
